### PR TITLE
fix: minor equipment defaulters bugs

### DIFF
--- a/api/src/schema/campaigns-equipment.graphql
+++ b/api/src/schema/campaigns-equipment.graphql
@@ -79,10 +79,10 @@ extend type GatheringService {
       MATCH (n:EquipmentDate)
       WITH max(n.date) as latestEquipmentDate, this
       MATCH (date:EquipmentDate {date:latestEquipmentDate})
-        MATCH (date)<-[:HAS_EQUIPMENT_DATE]-(record:EquipmentRecord)
+      OPTIONAL  MATCH (date)<-[:HAS_EQUIPMENT_DATE]-(record:EquipmentRecord)
        WITH DISTINCT date, this, record
 
-        MATCH (record)<-[:HAS_EQUIPMENT_RECORD]-(:ServiceLog)<-[:HAS_HISTORY]-(fellowships:Fellowship)
+       OPTIONAL MATCH (record)<-[:HAS_EQUIPMENT_RECORD]-(:ServiceLog)<-[:HAS_HISTORY]-(fellowships:Fellowship)
 
        WITH collect(DISTINCT fellowships) as filled, this
        MATCH (defaulters:Fellowship)<-[:HAS]-(bacenta:Bacenta)<-[:HAS]-(constituency:Constituency)<-[:HAS]-(:Council)<-[:HAS]-(:Stream)<-[:HAS]-(this)
@@ -99,10 +99,10 @@ extend type GatheringService {
       MATCH (n:EquipmentDate)
       WITH max(n.date) as latestEquipmentDate, this
       MATCH (date:EquipmentDate {date:latestEquipmentDate})
-        MATCH (date)<-[:HAS_EQUIPMENT_DATE]-(record:EquipmentRecord)
+      OPTIONAL  MATCH (date)<-[:HAS_EQUIPMENT_DATE]-(record:EquipmentRecord)
        WITH DISTINCT date, this, record
 
-        MATCH (record)<-[:HAS_EQUIPMENT_RECORD]-(:ServiceLog)<-[:HAS_HISTORY]-(fellowships:Fellowship)
+      OPTIONAL  MATCH (record)<-[:HAS_EQUIPMENT_RECORD]-(:ServiceLog)<-[:HAS_HISTORY]-(fellowships:Fellowship)
 
        WITH collect(DISTINCT fellowships) as filled, this
        MATCH (defaulters:Fellowship)<-[:HAS]-(bacenta:Bacenta)<-[:HAS]-(constituency:Constituency)<-[:HAS]-(:Council)<-[:HAS]-(:Stream)<-[:HAS]-(this)
@@ -150,10 +150,10 @@ extend type GatheringService {
       MATCH (n:EquipmentDate)
       WITH max(n.date) as latestEquipmentDate, this
       MATCH (date:EquipmentDate {date:latestEquipmentDate})
-       MATCH (date)<-[:HAS_EQUIPMENT_DATE]-(record:EquipmentRecord)
+      OPTIONAL MATCH (date)<-[:HAS_EQUIPMENT_DATE]-(record:EquipmentRecord)
        WITH DISTINCT date, this, record
 
-       MATCH (record)<-[:HAS_EQUIPMENT_RECORD]-(:ServiceLog)<-[:HAS_HISTORY]-(constituencies:Constituency)
+      OPTIONAL MATCH (record)<-[:HAS_EQUIPMENT_RECORD]-(:ServiceLog)<-[:HAS_HISTORY]-(constituencies:Constituency)
 
        WITH collect(DISTINCT constituencies) as filled, this
        MATCH (defaulters:Constituency)<-[:HAS]-(:Council)<-[:HAS]-(:Stream)<-[:HAS]-(this)
@@ -170,10 +170,10 @@ extend type GatheringService {
       MATCH (n:EquipmentDate)
       WITH max(n.date) as latestEquipmentDate, this
       MATCH (date:EquipmentDate {date:latestEquipmentDate})
-       MATCH (date)<-[:HAS_EQUIPMENT_DATE]-(record:EquipmentRecord)
+      OPTIONAL MATCH (date)<-[:HAS_EQUIPMENT_DATE]-(record:EquipmentRecord)
        WITH DISTINCT date, this, record
 
-       MATCH (record)<-[:HAS_EQUIPMENT_RECORD]-(:ServiceLog)<-[:HAS_HISTORY]-(constituencies:Constituency)
+      OPTIONAL MATCH (record)<-[:HAS_EQUIPMENT_RECORD]-(:ServiceLog)<-[:HAS_HISTORY]-(constituencies:Constituency)
 
        WITH collect(DISTINCT constituencies) as filled, this
        MATCH (defaulters:Constituency)<-[:HAS]-(:Council)<-[:HAS]-(:Stream)<-[:HAS]-(this)
@@ -224,10 +224,10 @@ extend type Stream {
       MATCH (n:EquipmentDate)
       WITH max(n.date) as latestEquipmentDate, this
       MATCH (date:EquipmentDate {date:latestEquipmentDate})
-        MATCH (date)<-[:HAS_EQUIPMENT_DATE]-(record:EquipmentRecord)
+      OPTIONAL  MATCH (date)<-[:HAS_EQUIPMENT_DATE]-(record:EquipmentRecord)
        WITH DISTINCT date, this, record
 
-        MATCH (record)<-[:HAS_EQUIPMENT_RECORD]-(:ServiceLog)<-[:HAS_HISTORY]-(fellowships:Fellowship)
+      OPTIONAL  MATCH (record)<-[:HAS_EQUIPMENT_RECORD]-(:ServiceLog)<-[:HAS_HISTORY]-(fellowships:Fellowship)
 
        WITH collect(DISTINCT fellowships) as filled, this
        MATCH (defaulters:Fellowship)<-[:HAS]-(bacenta:Bacenta)<-[:HAS]-(constituency:Constituency)<-[:HAS]-(:Council)<-[:HAS]-(this)
@@ -244,10 +244,10 @@ extend type Stream {
       MATCH (n:EquipmentDate)
       WITH max(n.date) as latestEquipmentDate, this
       MATCH (date:EquipmentDate {date:latestEquipmentDate})
-        MATCH (date)<-[:HAS_EQUIPMENT_DATE]-(record:EquipmentRecord)
+      OPTIONAL MATCH (date)<-[:HAS_EQUIPMENT_DATE]-(record:EquipmentRecord)
        WITH DISTINCT date, this, record
 
-        MATCH (record)<-[:HAS_EQUIPMENT_RECORD]-(:ServiceLog)<-[:HAS_HISTORY]-(fellowships:Fellowship)
+      OPTIONAL MATCH (record)<-[:HAS_EQUIPMENT_RECORD]-(:ServiceLog)<-[:HAS_HISTORY]-(fellowships:Fellowship)
 
        WITH collect(DISTINCT fellowships) as filled, this
        MATCH (defaulters:Fellowship)<-[:HAS]-(bacenta:Bacenta)<-[:HAS]-(constituency:Constituency)<-[:HAS]-(:Council)<-[:HAS]-(this)
@@ -295,10 +295,10 @@ extend type Stream {
       MATCH (n:EquipmentDate)
       WITH max(n.date) as latestEquipmentDate, this
       MATCH (date:EquipmentDate {date:latestEquipmentDate})
-        MATCH (date)<-[:HAS_EQUIPMENT_DATE]-(record:EquipmentRecord)
+      OPTIONAL MATCH (date)<-[:HAS_EQUIPMENT_DATE]-(record:EquipmentRecord)
        WITH DISTINCT date, this, record
 
-        MATCH (record)<-[:HAS_EQUIPMENT_RECORD]-(:ServiceLog)<-[:HAS_HISTORY]-(constituencies:Constituency)
+       OPTIONAL MATCH (record)<-[:HAS_EQUIPMENT_RECORD]-(:ServiceLog)<-[:HAS_HISTORY]-(constituencies:Constituency)
 
        WITH collect(DISTINCT constituencies) as filled, this
        MATCH (defaulters:Constituency)<-[:HAS]-(:Council)<-[:HAS]-(this)
@@ -315,10 +315,10 @@ extend type Stream {
       MATCH (n:EquipmentDate)
       WITH max(n.date) as latestEquipmentDate, this
       MATCH (date:EquipmentDate {date:latestEquipmentDate})
-        MATCH (date)<-[:HAS_EQUIPMENT_DATE]-(record:EquipmentRecord)
+      OPTIONAL MATCH (date)<-[:HAS_EQUIPMENT_DATE]-(record:EquipmentRecord)
        WITH DISTINCT date, this, record
 
-        MATCH (record)<-[:HAS_EQUIPMENT_RECORD]-(:ServiceLog)<-[:HAS_HISTORY]-(constituencies:Constituency)
+       OPTIONAL MATCH (record)<-[:HAS_EQUIPMENT_RECORD]-(:ServiceLog)<-[:HAS_HISTORY]-(constituencies:Constituency)
 
        WITH collect(DISTINCT constituencies) as filled, this
        MATCH (defaulters:Constituency)<-[:HAS]-(:Council)<-[:HAS]-(this)
@@ -440,7 +440,7 @@ extend type Council {
       MATCH (n:EquipmentDate)
       WITH max(n.date) as latestEquipmentDate, this
       MATCH (date:EquipmentDate {date:latestEquipmentDate})
-        MATCH (date)<-[:HAS_EQUIPMENT_DATE]-(record:EquipmentRecord)
+      OPTIONAL  MATCH (date)<-[:HAS_EQUIPMENT_DATE]-(record:EquipmentRecord)
        WITH DISTINCT date, this, record
 
         OPTIONAL MATCH (record)<-[:HAS_EQUIPMENT_RECORD]-(:ServiceLog)<-[:HAS_HISTORY]-(constituencies:Constituency)
@@ -460,7 +460,7 @@ extend type Council {
       MATCH (n:EquipmentDate)
       WITH max(n.date) as latestEquipmentDate, this
       MATCH (date:EquipmentDate {date:latestEquipmentDate})
-        MATCH (date)<-[:HAS_EQUIPMENT_DATE]-(record:EquipmentRecord)
+       OPTIONAL MATCH (date)<-[:HAS_EQUIPMENT_DATE]-(record:EquipmentRecord)
        WITH DISTINCT date, this, record
 
         OPTIONAL MATCH (record)<-[:HAS_EQUIPMENT_RECORD]-(:ServiceLog)<-[:HAS_HISTORY]-(constituencies:Constituency)
@@ -514,7 +514,7 @@ extend type Constituency {
       MATCH (n:EquipmentDate)
       WITH max(n.date) as latestEquipmentDate, this
       MATCH (date:EquipmentDate {date:latestEquipmentDate})
-        MATCH (date)<-[:HAS_EQUIPMENT_DATE]-(record:EquipmentRecord)
+      OPTIONAL MATCH (date)<-[:HAS_EQUIPMENT_DATE]-(record:EquipmentRecord)
        WITH DISTINCT date, this, record
 
        OPTIONAL MATCH (record)<-[:HAS_EQUIPMENT_RECORD]-(:ServiceLog)<-[:HAS_HISTORY]-(fellowships:Fellowship)
@@ -534,7 +534,7 @@ extend type Constituency {
       MATCH (n:EquipmentDate)
       WITH max(n.date) as latestEquipmentDate, this
       MATCH (date:EquipmentDate {date:latestEquipmentDate})
-        MATCH (date)<-[:HAS_EQUIPMENT_DATE]-(record:EquipmentRecord)
+      OPTIONAL MATCH (date)<-[:HAS_EQUIPMENT_DATE]-(record:EquipmentRecord)
        WITH DISTINCT date, this, record
 
        OPTIONAL MATCH (record)<-[:HAS_EQUIPMENT_RECORD]-(:ServiceLog)<-[:HAS_HISTORY]-(fellowships:Fellowship)

--- a/web-react-ts/src/pages/campaigns/CampaignQueries.ts
+++ b/web-react-ts/src/pages/campaigns/CampaignQueries.ts
@@ -291,6 +291,7 @@ export const CONSTITUENCY_EQUIPMENT_DEFAULTERS_NUMBER_BY_FELLOWSHIP = gql`
       id
       fellowshipEquipmentFilledCount
       fellowshipEquipmentNotFilledCount
+      fellowshipCount
     }
   }
 `

--- a/web-react-ts/src/pages/campaigns/CampaignQueries.ts
+++ b/web-react-ts/src/pages/campaigns/CampaignQueries.ts
@@ -18,7 +18,6 @@ export const GATHERING_SERVICE_TRENDS = gql`
       name
       campaigns
       equipmentRecord {
-        id
         bluetoothSpeakers
         offeringBags
         pulpits
@@ -38,7 +37,6 @@ export const GATHERING_SERVICE_BY_STREAM = gql`
         id
         name
         equipmentRecord {
-          id
           bluetoothSpeakers
           offeringBags
           pulpits
@@ -83,7 +81,6 @@ export const STREAM_TRENDS = gql`
       id
       name
       equipmentRecord {
-        id
         bluetoothSpeakers
         offeringBags
         pulpits
@@ -103,7 +100,6 @@ export const STREAM_BY_COUNCIL = gql`
         id
         name
         equipmentRecord {
-          id
           bluetoothSpeakers
           offeringBags
           pulpits
@@ -132,7 +128,6 @@ export const COUNCIL_TRENDS = gql`
       id
       name
       equipmentRecord {
-        id
         bluetoothSpeakers
         offeringBags
         pulpits
@@ -281,7 +276,6 @@ export const CONSTITUENCY_BY_BACENTA = gql`
         id
         name
         equipmentRecord {
-          id
           bluetoothSpeakers
           offeringBags
         }
@@ -339,7 +333,6 @@ export const BACENTA_TRENDS = gql`
       id
       name
       equipmentRecord {
-        id
         offeringBags
         bluetoothSpeakers
       }

--- a/web-react-ts/src/pages/campaigns/equipment/constituency/ConstituencyEquipmentDefaulters.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/constituency/ConstituencyEquipmentDefaulters.tsx
@@ -36,6 +36,12 @@ function ConstituencyEquipmentDefaulters() {
           </div>
           <h6 className="mt-4">Fellowships that haven't filled their form</h6>
           <div className=" gap-2 mt-4">
+            <h6>
+              Fellowships :{' '}
+              <span className="text-primary">
+                {constituency?.fellowshipCount}
+              </span>
+            </h6>
             <Row>
               <Col>
                 <DefaultersMenuButton


### PR DESCRIPTION
1. Some of the defaulters pages weren’t loading, because the query was looking for an ID field that didn’t exist on equipment record
2. Left out the optional match on date for the not filled defaulter queries. This made the Not Filled defaulter return 0 instead of the number of churches.
3. Added the number of fellowships on the constituency defaulters page