### PR TITLE
Fix/equipment deadline up

### DIFF
--- a/api/src/resolvers/campaigns/campaigns-resolver.ts
+++ b/api/src/resolvers/campaigns/campaigns-resolver.ts
@@ -153,7 +153,7 @@ export const campaignsMutation = {
         )
       }
 
-      const currentDate = new Date(args.date)
+      const currentDate = new Date()
       const startDate = new Date(equipmentCampaign.campaign.equipmentStartDate)
       const endDate = new Date(equipmentCampaign.campaign.equipmentEndDate)
 
@@ -163,7 +163,6 @@ export const campaignsMutation = {
         const equipmentRecordExists = rearrangeCypherObject(
           await session.run(checkExistingEquipmentRecord, {
             id: args.id,
-            pulpits: args.pulpits,
             date,
           })
         )
@@ -218,7 +217,7 @@ export const campaignsMutation = {
         )
       }
 
-      const currentDate = new Date(args.date)
+      const currentDate = new Date()
       const startDate = new Date(equipmentCampaign.campaign.equipmentStartDate)
       const endDate = new Date(equipmentCampaign.campaign.equipmentEndDate)
 
@@ -228,7 +227,6 @@ export const campaignsMutation = {
         const equipmentRecordExists = rearrangeCypherObject(
           await session.run(checkExistingEquipmentRecord, {
             id: args.id,
-            offeringBags: args.offeringBags,
             date,
           })
         )


### PR DESCRIPTION
<!--THIS PROJECT IS IN MAINTENANCE MODE. We accept pull-requests for Bug Fixes **ONLY**. NO NEW FEATURES ACCEPTED!-->

<!--- Provide a general summary of your changes in the Title above -->
This PR fixes the issue where a leader receives the message "Equipment Deadline Up!" even when the deadline is not really up.

## Description
<!--- Describe your changes in detail -->
Changes the date variable used by the fill equipment forms to a date generated by the server.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

<!--## Motivation and Context-->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It has been tested on my localhost and proved to be working.

## Screenshots (if appropriate):