### PR TITLE
fix: change active fellowship count to fellowshipCount in campaign trends

### DIFF
--- a/web-react-ts/src/global-types.ts
+++ b/web-react-ts/src/global-types.ts
@@ -271,7 +271,7 @@ export type EquipmentChurch = {
   id: string
   name: string
   equipmentRecord: EquipmentRecord
-  activeFellowshipCount: number
+  fellowshipCount: number
   constituencyCount: number
 }
 

--- a/web-react-ts/src/pages/campaigns/CampaignQueries.ts
+++ b/web-react-ts/src/pages/campaigns/CampaignQueries.ts
@@ -22,7 +22,7 @@ export const GATHERING_SERVICE_TRENDS = gql`
         offeringBags
         pulpits
       }
-      activeFellowshipCount
+      fellowshipCount
       constituencyCount
     }
   }
@@ -42,7 +42,7 @@ export const GATHERING_SERVICE_BY_STREAM = gql`
           pulpits
         }
         constituencyCount
-        activeFellowshipCount
+        fellowshipCount
       }
     }
   }
@@ -85,7 +85,7 @@ export const STREAM_TRENDS = gql`
         offeringBags
         pulpits
       }
-      activeFellowshipCount
+      fellowshipCount
       constituencyCount
     }
   }
@@ -104,7 +104,7 @@ export const STREAM_BY_COUNCIL = gql`
           offeringBags
           pulpits
         }
-        activeFellowshipCount
+        fellowshipCount
         constituencyCount
       }
     }
@@ -132,7 +132,7 @@ export const COUNCIL_TRENDS = gql`
         offeringBags
         pulpits
       }
-      activeFellowshipCount
+      fellowshipCount
       constituencyCount
     }
   }
@@ -152,7 +152,7 @@ export const COUNCIL_BY_CONSTITUENCY = gql`
           offeringBags
           pulpits
         }
-        activeFellowshipCount
+        fellowshipCount
       }
     }
   }
@@ -234,7 +234,7 @@ export const CONSTITUENCY_TRENDS = gql`
         offeringBags
         pulpits
       }
-      activeFellowshipCount
+      fellowshipCount
     }
   }
 `
@@ -279,7 +279,7 @@ export const CONSTITUENCY_BY_BACENTA = gql`
           bluetoothSpeakers
           offeringBags
         }
-        activeFellowshipCount
+        fellowshipCount
       }
     }
   }
@@ -337,7 +337,7 @@ export const BACENTA_TRENDS = gql`
         offeringBags
         bluetoothSpeakers
       }
-      activeFellowshipCount
+      fellowshipCount
     }
   }
 `
@@ -347,7 +347,7 @@ export const BACENTA_BY_FELLOWSHIP = gql`
     bacentas(where: { id: $bacentaId }) {
       id
       name
-      activeFellowshipCount
+      fellowshipCount
       fellowships {
         id
         name

--- a/web-react-ts/src/pages/campaigns/components/buttons/FellowshipTrendsButton.tsx
+++ b/web-react-ts/src/pages/campaigns/components/buttons/FellowshipTrendsButton.tsx
@@ -15,9 +15,9 @@ const FellowshipTrendsButton = (props: TrendsButtonProps) => {
   const bluetoothSpeakers = church?.equipmentRecord?.bluetoothSpeakers
 
   const totalOfferingBags =
-    churchType === 'Fellowship' ? 1 : church?.activeFellowshipCount
+    churchType === 'Fellowship' ? 1 : church?.fellowshipCount
   const totalBluetoothSpeakers =
-    churchType === 'Fellowship' ? 1 : church?.activeFellowshipCount
+    churchType === 'Fellowship' ? 1 : church?.fellowshipCount
   const offeringBagsPercentage = Math.round(
     (offeringBags / totalOfferingBags) * 100
   )

--- a/web-react-ts/src/pages/campaigns/components/buttons/TrendsButton.tsx
+++ b/web-react-ts/src/pages/campaigns/components/buttons/TrendsButton.tsx
@@ -22,13 +22,13 @@ const TrendsButton = (props: TrendsButtonProps) => {
   const name = church?.name
   const constituencyCount =
     churchType === 'Constituency' ? 1 : church?.constituencyCount
-  const activeFellowshipCount = church?.activeFellowshipCount
+  const fellowshipCount = church?.fellowshipCount
   const offeringBagsPercentage = Math.round(
-    (offeringBags / activeFellowshipCount) * 100
+    (offeringBags / fellowshipCount) * 100
   )
   const pulpitsPercentage = Math.round((pulpits / constituencyCount) * 100)
   const bluetoothSpeakersPercentage = Math.round(
-    (bluetoothSpeakers / activeFellowshipCount) * 100
+    (bluetoothSpeakers / fellowshipCount) * 100
   )
 
   return (
@@ -44,7 +44,7 @@ const TrendsButton = (props: TrendsButtonProps) => {
       </div>
       <div className="d-grid gap-1 pb-2">
         <div className="lowercase-text text-secondary">
-          Offering Bags: {offeringBags} / {activeFellowshipCount}
+          Offering Bags: {offeringBags} / {fellowshipCount}
         </div>
         <ProgressBar percentage={offeringBagsPercentage} />
         <div className="lowercase-text text-secondary">
@@ -52,7 +52,7 @@ const TrendsButton = (props: TrendsButtonProps) => {
         </div>
         <ProgressBar percentage={pulpitsPercentage} />
         <div className="lowercase-text text-secondary">
-          Bluetooth Speakers: {bluetoothSpeakers} / {activeFellowshipCount}
+          Bluetooth Speakers: {bluetoothSpeakers} / {fellowshipCount}
         </div>
         <ProgressBar percentage={bluetoothSpeakersPercentage} />
       </div>


### PR DESCRIPTION
<!--THIS PROJECT IS IN MAINTENANCE MODE. We accept pull-requests for Bug Fixes **ONLY**. NO NEW FEATURES ACCEPTED!-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I changed active fellowship count to fellowshipCount in campaign trends and queries

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

<!--## Motivation and Context-->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):