### PR TITLE
fix: fix constituency record null id error

### DIFF
--- a/api/src/resolvers/campaigns/campaigns-resolver.ts
+++ b/api/src/resolvers/campaigns/campaigns-resolver.ts
@@ -322,7 +322,7 @@ const getEquipmentDetails = async (
     // eslint-disable-next-line no-underscore-dangle
     pulpits = constituencyEquipmentResponse.records[0]._fields[0].pulpits.low
   } else {
-    id = args?.id
+    id = obj?.id
   }
 
   const bluetoothSpeakers =


### PR DESCRIPTION
<!--THIS PROJECT IS IN MAINTENANCE MODE. We accept pull-requests for Bug Fixes **ONLY**. NO NEW FEATURES ACCEPTED!-->

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This PR fixes the issue of null constituency record ids in the equipment campaign records.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

<!--## Motivation and Context-->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
This has been tested on my localhost and proven to be working

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
