### PR TITLE
feat: implement equipment deadline on the equipment main page

### DIFF
--- a/web-react-ts/src/pages/campaigns/CampaignQueries.ts
+++ b/web-react-ts/src/pages/campaigns/CampaignQueries.ts
@@ -64,6 +64,15 @@ export const SET_EQUIPMENT_DEADLINE = gql`
   }
 `
 
+export const EQUIPMENT_END_DATE = gql`
+  query equipmentEndDate($gatheringServiceId: ID) {
+    gatheringServices(where: { id: $gatheringServiceId }) {
+      id
+      equipmentEndDate
+    }
+  }
+`
+
 //Streams Queries and Mutations
 export const STREAM_CAMPAIGN_LIST = gql`
   query streamCampaigns($streamId: ID) {

--- a/web-react-ts/src/pages/campaigns/equipment/bacenta/BacentaEquipmentCampaign.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/bacenta/BacentaEquipmentCampaign.tsx
@@ -31,7 +31,7 @@ const BacentaEquipmentCampaign = () => {
           <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
           <HeadingSecondary>Equipment Campaign</HeadingSecondary>
         </div>
-        <h6 className="text-danger">
+        <h6 className="text-danger text-center">
           Current Deadline : {getHumanReadableDate(equipmentEndDate)}{' '}
         </h6>
         <div className="d-grid gap-2 mt-4 text-center px-4">

--- a/web-react-ts/src/pages/campaigns/equipment/bacenta/BacentaEquipmentCampaign.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/bacenta/BacentaEquipmentCampaign.tsx
@@ -5,10 +5,22 @@ import { useNavigate } from 'react-router'
 import { MemberContext } from 'contexts/MemberContext'
 import { HeadingPrimary } from 'components/HeadingPrimary/HeadingPrimary'
 import HeadingSecondary from 'components/HeadingSecondary'
+import { EQUIPMENT_END_DATE } from 'pages/campaigns/CampaignQueries'
+import { useQuery } from '@apollo/client'
+import { getHumanReadableDate } from 'jd-date-utils'
 
 const BacentaEquipmentCampaign = () => {
   const { currentUser } = useContext(MemberContext)
   const navigate = useNavigate()
+  const gatheringServiceId = currentUser?.gatheringService
+
+  const { data } = useQuery(EQUIPMENT_END_DATE, {
+    variables: {
+      gatheringServiceId: gatheringServiceId,
+    },
+  })
+
+  const equipmentEndDate = data?.gatheringServices[0]?.equipmentEndDate
 
   const church = currentUser.currentChurch
   const churchType = currentUser.currentChurch?.__typename
@@ -19,6 +31,9 @@ const BacentaEquipmentCampaign = () => {
           <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
           <HeadingSecondary>Equipment Campaign</HeadingSecondary>
         </div>
+        <h6 className="text-danger">
+          Current Deadline : {getHumanReadableDate(equipmentEndDate)}{' '}
+        </h6>
         <div className="d-grid gap-2 mt-4 text-center px-4">
           <MenuButton
             name="View Trends"

--- a/web-react-ts/src/pages/campaigns/equipment/constituency/ConstituencyEquipmentCampaign.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/constituency/ConstituencyEquipmentCampaign.tsx
@@ -3,13 +3,17 @@ import { Container } from 'react-bootstrap'
 import MenuButton from '../../components/buttons/MenuButton'
 import { useNavigate } from 'react-router'
 import { MemberContext } from 'contexts/MemberContext'
-import { CONSTITUENCY_LATEST_EQUIPMENT_RECORD } from 'pages/campaigns/CampaignQueries'
+import {
+  CONSTITUENCY_LATEST_EQUIPMENT_RECORD,
+  EQUIPMENT_END_DATE,
+} from 'pages/campaigns/CampaignQueries'
 import { useQuery } from '@apollo/client'
 import { ChurchContext } from 'contexts/ChurchContext'
 import RoleView from 'auth/RoleView'
 import { permitAdmin } from 'permission-utils'
 import { HeadingPrimary } from 'components/HeadingPrimary/HeadingPrimary'
 import HeadingSecondary from 'components/HeadingSecondary'
+import { getHumanReadableDate } from 'jd-date-utils'
 
 const ConstituencyEquipmentCampaign = () => {
   const { currentUser } = useContext(MemberContext)
@@ -18,6 +22,7 @@ const ConstituencyEquipmentCampaign = () => {
   const church = currentUser.currentChurch
   const churchType = currentUser.currentChurch?.__typename
   const { constituencyId } = useContext(ChurchContext)
+  const gatheringServiceId = currentUser?.gatheringService
 
   const { data } = useQuery(CONSTITUENCY_LATEST_EQUIPMENT_RECORD, {
     variables: {
@@ -27,6 +32,15 @@ const ConstituencyEquipmentCampaign = () => {
 
   const constituencyEquipmentRecord = data?.constituencies[0]?.equipmentRecord
 
+  const { data: equipmentEndDateData } = useQuery(EQUIPMENT_END_DATE, {
+    variables: {
+      gatheringServiceId: gatheringServiceId,
+    },
+  })
+
+  const equipmentEndDate =
+    equipmentEndDateData?.gatheringServices[0]?.equipmentEndDate
+
   return (
     <div className="d-flex align-items-center justify-content-center ">
       <Container>
@@ -34,7 +48,9 @@ const ConstituencyEquipmentCampaign = () => {
           <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
           <HeadingSecondary>Equipment Campaign</HeadingSecondary>
         </div>
-
+        <h6 className="text-danger">
+          Current Deadline : {getHumanReadableDate(equipmentEndDate)}{' '}
+        </h6>
         <div className="d-grid gap-2 mt-4 text-center px-4">
           {constituencyEquipmentRecord?.pulpits === null && (
             <MenuButton

--- a/web-react-ts/src/pages/campaigns/equipment/constituency/ConstituencyEquipmentCampaign.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/constituency/ConstituencyEquipmentCampaign.tsx
@@ -48,7 +48,7 @@ const ConstituencyEquipmentCampaign = () => {
           <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
           <HeadingSecondary>Equipment Campaign</HeadingSecondary>
         </div>
-        <h6 className="text-danger">
+        <h6 className="text-danger text-center">
           Current Deadline : {getHumanReadableDate(equipmentEndDate)}{' '}
         </h6>
         <div className="d-grid gap-2 mt-4 text-center px-4">

--- a/web-react-ts/src/pages/campaigns/equipment/council/CouncilEquipmentCampaign.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/council/CouncilEquipmentCampaign.tsx
@@ -33,7 +33,7 @@ const CouncilEquipmentCampaign = () => {
           <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
           <HeadingSecondary>Equipment Campaign</HeadingSecondary>
         </div>
-        <h6 className="text-danger">
+        <h6 className="text-danger text-center">
           Current Deadline : {getHumanReadableDate(equipmentEndDate)}{' '}
         </h6>
         <div className="d-grid gap-2 mt-4 text-center px-4">

--- a/web-react-ts/src/pages/campaigns/equipment/council/CouncilEquipmentCampaign.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/council/CouncilEquipmentCampaign.tsx
@@ -7,10 +7,22 @@ import RoleView from 'auth/RoleView'
 import { permitAdmin } from 'permission-utils'
 import { HeadingPrimary } from 'components/HeadingPrimary/HeadingPrimary'
 import HeadingSecondary from 'components/HeadingSecondary'
+import { EQUIPMENT_END_DATE } from 'pages/campaigns/CampaignQueries'
+import { useQuery } from '@apollo/client'
+import { getHumanReadableDate } from 'jd-date-utils'
 
 const CouncilEquipmentCampaign = () => {
   const { currentUser } = useContext(MemberContext)
   const navigate = useNavigate()
+  const gatheringServiceId = currentUser?.gatheringService
+
+  const { data } = useQuery(EQUIPMENT_END_DATE, {
+    variables: {
+      gatheringServiceId: gatheringServiceId,
+    },
+  })
+
+  const equipmentEndDate = data?.gatheringServices[0]?.equipmentEndDate
 
   const church = currentUser.currentChurch
   const churchType = currentUser.currentChurch?.__typename
@@ -21,6 +33,9 @@ const CouncilEquipmentCampaign = () => {
           <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
           <HeadingSecondary>Equipment Campaign</HeadingSecondary>
         </div>
+        <h6 className="text-danger">
+          Current Deadline : {getHumanReadableDate(equipmentEndDate)}{' '}
+        </h6>
         <div className="d-grid gap-2 mt-4 text-center px-4">
           <MenuButton
             name="View Trends"

--- a/web-react-ts/src/pages/campaigns/equipment/fellowship/FellowshipEquipmentCampaign.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/fellowship/FellowshipEquipmentCampaign.tsx
@@ -3,11 +3,15 @@ import { Container } from 'react-bootstrap'
 import MenuButton from '../../components/buttons/MenuButton'
 import { useNavigate } from 'react-router'
 import { MemberContext } from 'contexts/MemberContext'
-import { FELLOWSHIP_LATEST_EQUIPMENT_RECORD } from 'pages/campaigns/CampaignQueries'
+import {
+  FELLOWSHIP_LATEST_EQUIPMENT_RECORD,
+  EQUIPMENT_END_DATE,
+} from 'pages/campaigns/CampaignQueries'
 import { useQuery } from '@apollo/client'
 import { ChurchContext } from 'contexts/ChurchContext'
 import { HeadingPrimary } from 'components/HeadingPrimary/HeadingPrimary'
 import HeadingSecondary from 'components/HeadingSecondary'
+import { getHumanReadableDate } from 'jd-date-utils'
 
 const FellowshipEquipmentCampaign = () => {
   const { currentUser } = useContext(MemberContext)
@@ -16,6 +20,7 @@ const FellowshipEquipmentCampaign = () => {
   const church = currentUser.currentChurch
   const churchType = currentUser.currentChurch?.__typename
   const { fellowshipId } = useContext(ChurchContext)
+  const gatheringServiceId = currentUser?.gatheringService
 
   const { data } = useQuery(FELLOWSHIP_LATEST_EQUIPMENT_RECORD, {
     variables: {
@@ -25,6 +30,15 @@ const FellowshipEquipmentCampaign = () => {
 
   const fellowshipEquipmentRecord = data?.fellowships[0]?.equipmentRecord
 
+  const { data: equipmentEndDateData } = useQuery(EQUIPMENT_END_DATE, {
+    variables: {
+      gatheringServiceId: gatheringServiceId,
+    },
+  })
+
+  const equipmentEndDate =
+    equipmentEndDateData?.gatheringServices[0]?.equipmentEndDate
+
   return (
     <div className="d-flex align-items-center justify-content-center ">
       <Container>
@@ -32,6 +46,9 @@ const FellowshipEquipmentCampaign = () => {
           <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
           <HeadingSecondary>Equipment Campaign</HeadingSecondary>
         </div>
+        <h6 className="text-danger">
+          Current Deadline : {getHumanReadableDate(equipmentEndDate)}{' '}
+        </h6>
         <div className="d-grid gap-2 mt-4 text-center px-4">
           {fellowshipEquipmentRecord === null && (
             <MenuButton

--- a/web-react-ts/src/pages/campaigns/equipment/fellowship/FellowshipEquipmentCampaign.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/fellowship/FellowshipEquipmentCampaign.tsx
@@ -46,7 +46,7 @@ const FellowshipEquipmentCampaign = () => {
           <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
           <HeadingSecondary>Equipment Campaign</HeadingSecondary>
         </div>
-        <h6 className="text-danger">
+        <h6 className="text-danger text-center">
           Current Deadline : {getHumanReadableDate(equipmentEndDate)}{' '}
         </h6>
         <div className="d-grid gap-2 mt-4 text-center px-4">

--- a/web-react-ts/src/pages/campaigns/equipment/gathering-service/GatheringServiceEquipmentCampaign.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/gathering-service/GatheringServiceEquipmentCampaign.tsx
@@ -5,12 +5,24 @@ import { useNavigate } from 'react-router'
 import { MemberContext } from 'contexts/MemberContext'
 import { HeadingPrimary } from 'components/HeadingPrimary/HeadingPrimary'
 import HeadingSecondary from 'components/HeadingSecondary'
+import { EQUIPMENT_END_DATE } from 'pages/campaigns/CampaignQueries'
+import { useQuery } from '@apollo/client'
+import { getHumanReadableDate } from 'jd-date-utils'
 
 const GatheringServiceEquipmentCampaign = () => {
   const { currentUser } = useContext(MemberContext)
   const navigate = useNavigate()
 
   const church = currentUser.currentChurch
+  const gatheringServiceId = currentUser?.gatheringService
+
+  const { data } = useQuery(EQUIPMENT_END_DATE, {
+    variables: {
+      gatheringServiceId: gatheringServiceId,
+    },
+  })
+
+  const equipmentEndDate = data?.gatheringServices[0]?.equipmentEndDate
 
   return (
     <div className="d-flex align-items-center justify-content-center ">
@@ -19,6 +31,9 @@ const GatheringServiceEquipmentCampaign = () => {
           <HeadingPrimary>{`${church?.name} Gathering Service`}</HeadingPrimary>
           <HeadingSecondary>Equipment Campaign</HeadingSecondary>
         </div>
+        <h6 className="text-danger">
+          Current Deadline : {getHumanReadableDate(equipmentEndDate)}{' '}
+        </h6>
         <div className="d-grid gap-2 mt-4 text-center px-4">
           <MenuButton
             name="View Trends"

--- a/web-react-ts/src/pages/campaigns/equipment/gathering-service/GatheringServiceEquipmentCampaign.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/gathering-service/GatheringServiceEquipmentCampaign.tsx
@@ -31,7 +31,7 @@ const GatheringServiceEquipmentCampaign = () => {
           <HeadingPrimary>{`${church?.name} Gathering Service`}</HeadingPrimary>
           <HeadingSecondary>Equipment Campaign</HeadingSecondary>
         </div>
-        <h6 className="text-danger">
+        <h6 className="text-danger text-center">
           Current Deadline : {getHumanReadableDate(equipmentEndDate)}{' '}
         </h6>
         <div className="d-grid gap-2 mt-4 text-center px-4">

--- a/web-react-ts/src/pages/campaigns/equipment/stream/StreamEquipmentCampaign.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/stream/StreamEquipmentCampaign.tsx
@@ -32,7 +32,7 @@ const StreamEquipmentCampaign = () => {
           <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
           <HeadingSecondary>Equipment Campaign</HeadingSecondary>
         </div>
-        <h6 className="text-danger">
+        <h6 className="text-danger text-center">
           Current Deadline : {getHumanReadableDate(equipmentEndDate)}{' '}
         </h6>
         <div className="d-grid gap-2 mt-4 text-center px-4">

--- a/web-react-ts/src/pages/campaigns/equipment/stream/StreamEquipmentCampaign.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/stream/StreamEquipmentCampaign.tsx
@@ -5,6 +5,9 @@ import { useNavigate } from 'react-router'
 import { MemberContext } from 'contexts/MemberContext'
 import { HeadingPrimary } from 'components/HeadingPrimary/HeadingPrimary'
 import HeadingSecondary from 'components/HeadingSecondary'
+import { EQUIPMENT_END_DATE } from 'pages/campaigns/CampaignQueries'
+import { useQuery } from '@apollo/client'
+import { getHumanReadableDate } from 'jd-date-utils'
 
 const StreamEquipmentCampaign = () => {
   const { currentUser } = useContext(MemberContext)
@@ -12,6 +15,16 @@ const StreamEquipmentCampaign = () => {
 
   const church = currentUser.currentChurch
   const churchType = currentUser.currentChurch?.__typename
+  const gatheringServiceId = currentUser?.gatheringService
+
+  const { data } = useQuery(EQUIPMENT_END_DATE, {
+    variables: {
+      gatheringServiceId: gatheringServiceId,
+    },
+  })
+
+  const equipmentEndDate = data?.gatheringServices[0]?.equipmentEndDate
+
   return (
     <div className="d-flex align-items-center justify-content-center ">
       <Container>
@@ -19,6 +32,9 @@ const StreamEquipmentCampaign = () => {
           <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
           <HeadingSecondary>Equipment Campaign</HeadingSecondary>
         </div>
+        <h6 className="text-danger">
+          Current Deadline : {getHumanReadableDate(equipmentEndDate)}{' '}
+        </h6>
         <div className="d-grid gap-2 mt-4 text-center px-4">
           <MenuButton
             name="View Trends"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Added equipment deadline to the so to the main equipment pages of the various church levels so a user can know when the equipment season is ending"

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/Videos (if appropriate):

<!--Not optional. Please oblige so that your PR will be merged in due time!-->
![localhost_3000_campaigns_council_equipment(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/36607706/189074429-1ab2f35d-b849-4077-aa6a-17a0337c32f5.png)

