### PR TITLE
feat: implement pull to refresh feature on equipment defaulters pages

### DIFF
--- a/web-react-ts/src/pages/campaigns/equipment/constituency/ConstituencyEquipmentDefaulters.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/constituency/ConstituencyEquipmentDefaulters.tsx
@@ -9,6 +9,7 @@ import { useQuery } from '@apollo/client'
 import { CONSTITUENCY_EQUIPMENT_DEFAULTERS_NUMBER_BY_FELLOWSHIP } from 'pages/campaigns/CampaignQueries'
 import { HeadingPrimary } from 'components/HeadingPrimary/HeadingPrimary'
 import HeadingSecondary from 'components/HeadingSecondary'
+import PullToRefresh from 'react-simple-pull-to-refresh'
 
 function ConstituencyEquipmentDefaulters() {
   const { currentUser } = useContext(MemberContext)
@@ -18,7 +19,7 @@ function ConstituencyEquipmentDefaulters() {
   const churchType = currentUser.currentChurch?.__typename
   const { constituencyId } = useContext(ChurchContext)
 
-  const { data, loading, error } = useQuery(
+  const { data, loading, error, refetch } = useQuery(
     CONSTITUENCY_EQUIPMENT_DEFAULTERS_NUMBER_BY_FELLOWSHIP,
     {
       variables: {
@@ -29,47 +30,51 @@ function ConstituencyEquipmentDefaulters() {
   const constituency = data?.constituencies[0]
 
   return (
-    <ApolloWrapper data={data} loading={loading} error={error}>
-      <div className="d-flex align-items-center justify-content-center ">
-        <Container>
-          <div className="text-center">
-            <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
-            <HeadingSecondary>Equipment Campaign</HeadingSecondary>
-          </div>
-          <h6 className="mt-4">Fellowships that haven't filled their form</h6>
-          <div className=" gap-2 mt-4">
-            <h6>
-              Fellowships :{' '}
-              <span className="text-primary">
-                {constituency?.fellowshipCount}
-              </span>
-            </h6>
-            <Row>
-              <Col>
-                <DefaultersMenuButton
-                  name="Have not filled"
-                  onClick={() => {
-                    navigate(
-                      `/campaigns/constituency/equipment/have-not-filled/fellowship`
-                    )
-                  }}
-                  number={constituency?.fellowshipEquipmentNotFilledCount}
-                  color="text-danger"
-                />
-              </Col>
-              <Col>
-                <DefaultersMenuButton
-                  name="Filled"
-                  onClick={() => {}}
-                  number={constituency?.fellowshipEquipmentFilledCount}
-                  color="text-success"
-                />
-              </Col>
-            </Row>
-          </div>
-        </Container>
-      </div>
-    </ApolloWrapper>
+    <PullToRefresh
+      onRefresh={() => refetch({ constituencyId: constituencyId })}
+    >
+      <ApolloWrapper data={data} loading={loading} error={error}>
+        <div className="d-flex align-items-center justify-content-center ">
+          <Container>
+            <div className="text-center">
+              <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
+              <HeadingSecondary>Equipment Campaign</HeadingSecondary>
+            </div>
+            <h6 className="mt-4">Fellowships that haven't filled their form</h6>
+            <div className=" gap-2 mt-4">
+              <h6>
+                Fellowships :{' '}
+                <span className="text-primary">
+                  {constituency?.fellowshipCount}
+                </span>
+              </h6>
+              <Row>
+                <Col>
+                  <DefaultersMenuButton
+                    name="Have not filled"
+                    onClick={() => {
+                      navigate(
+                        `/campaigns/constituency/equipment/have-not-filled/fellowship`
+                      )
+                    }}
+                    number={constituency?.fellowshipEquipmentNotFilledCount}
+                    color="text-danger"
+                  />
+                </Col>
+                <Col>
+                  <DefaultersMenuButton
+                    name="Filled"
+                    onClick={() => {}}
+                    number={constituency?.fellowshipEquipmentFilledCount}
+                    color="text-success"
+                  />
+                </Col>
+              </Row>
+            </div>
+          </Container>
+        </div>
+      </ApolloWrapper>
+    </PullToRefresh>
   )
 }
 

--- a/web-react-ts/src/pages/campaigns/equipment/constituency/ConstituencyEquipmentHaveNotFilledByFellowship.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/constituency/ConstituencyEquipmentHaveNotFilledByFellowship.tsx
@@ -10,6 +10,7 @@ import { CONSTITUENCY_EQUIPMENT_DEFAULTERS_LIST_BY_FELLOWSHIP } from 'pages/camp
 import ApolloWrapper from 'components/base-component/ApolloWrapper'
 import { HeadingPrimary } from 'components/HeadingPrimary/HeadingPrimary'
 import HeadingSecondary from 'components/HeadingSecondary'
+import PullToRefresh from 'react-simple-pull-to-refresh'
 
 const ConstituencyEquipmentHaveNotFilledByFellowship = () => {
   const { currentUser } = useContext(MemberContext)
@@ -18,7 +19,7 @@ const ConstituencyEquipmentHaveNotFilledByFellowship = () => {
   const churchType = currentUser.currentChurch?.__typename
   const { constituencyId } = useContext(ChurchContext)
 
-  const { data, loading, error } = useQuery(
+  const { data, loading, error, refetch } = useQuery(
     CONSTITUENCY_EQUIPMENT_DEFAULTERS_LIST_BY_FELLOWSHIP,
     {
       variables: {
@@ -30,26 +31,30 @@ const ConstituencyEquipmentHaveNotFilledByFellowship = () => {
   const defaulters = data?.constituencies[0]?.fellowshipEquipmentNotFilled
 
   return (
-    <ApolloWrapper data={data} loading={loading} error={error}>
-      <div className="d-flex align-items-center justify-content-center ">
-        <Container>
-          <div className="text-center">
-            <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
-            <HeadingSecondary>Equipment Campaign</HeadingSecondary>
-          </div>
-          <h6 className="mt-4">Fellowships that haven't filled their form</h6>
+    <PullToRefresh
+      onRefresh={() => refetch({ constituencyId: constituencyId })}
+    >
+      <ApolloWrapper data={data} loading={loading} error={error}>
+        <div className="d-flex align-items-center justify-content-center ">
           <Container>
-            <Row>
-              {defaulters?.map(
-                (defaulter: EquipmentDefaulterProps, index: number) => (
-                  <DefaultersCard key={index} defaulter={defaulter} />
-                )
-              )}
-            </Row>
+            <div className="text-center">
+              <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
+              <HeadingSecondary>Equipment Campaign</HeadingSecondary>
+            </div>
+            <h6 className="mt-4">Fellowships that haven't filled their form</h6>
+            <Container>
+              <Row>
+                {defaulters?.map(
+                  (defaulter: EquipmentDefaulterProps, index: number) => (
+                    <DefaultersCard key={index} defaulter={defaulter} />
+                  )
+                )}
+              </Row>
+            </Container>
           </Container>
-        </Container>
-      </div>
-    </ApolloWrapper>
+        </div>
+      </ApolloWrapper>
+    </PullToRefresh>
   )
 }
 

--- a/web-react-ts/src/pages/campaigns/equipment/council/CouncilEquipmentDefaulters.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/council/CouncilEquipmentDefaulters.tsx
@@ -9,6 +9,7 @@ import { COUNCIL_EQUIPMENT_DEFAULTERS_NUMBER_BY_CONSTITUENCY_AND_FELLOWSHIP } fr
 import ApolloWrapper from 'components/base-component/ApolloWrapper'
 import { HeadingPrimary } from 'components/HeadingPrimary/HeadingPrimary'
 import HeadingSecondary from 'components/HeadingSecondary'
+import PullToRefresh from 'react-simple-pull-to-refresh'
 
 const CouncilEquipmentDefaulters = () => {
   const { currentUser } = useContext(MemberContext)
@@ -18,7 +19,7 @@ const CouncilEquipmentDefaulters = () => {
   const churchType = currentUser.currentChurch?.__typename
   const { councilId } = useContext(ChurchContext)
 
-  const { data, loading, error } = useQuery(
+  const { data, loading, error, refetch } = useQuery(
     COUNCIL_EQUIPMENT_DEFAULTERS_NUMBER_BY_CONSTITUENCY_AND_FELLOWSHIP,
     {
       variables: {
@@ -29,75 +30,79 @@ const CouncilEquipmentDefaulters = () => {
   const council = data?.councils[0]
 
   return (
-    <ApolloWrapper data={data} loading={loading} error={error}>
-      <div className="d-flex align-items-center justify-content-center ">
-        <Container>
-          <div className="text-center">
-            <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
-            <HeadingSecondary>Equipment Campaign</HeadingSecondary>
-          </div>
-          <h6 className="mt-4">
-            Fellowships and Constituencies that haven't filled their form
-          </h6>
-          <div className=" gap-2 mt-4">
-            <h6>
-              Fellowships :{' '}
-              <span className="text-primary">{council?.fellowshipCount}</span>
+    <PullToRefresh onRefresh={() => refetch({ councilId: councilId })}>
+      <ApolloWrapper data={data} loading={loading} error={error}>
+        <div className="d-flex align-items-center justify-content-center ">
+          <Container>
+            <div className="text-center">
+              <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
+              <HeadingSecondary>Equipment Campaign</HeadingSecondary>
+            </div>
+            <h6 className="mt-4">
+              Fellowships and Constituencies that haven't filled their form
             </h6>
-            <Row className="mt-3">
-              <Col>
-                <DefaultersMenuButton
-                  name="Have not filled"
-                  onClick={() => {
-                    navigate(
-                      `/campaigns/council/equipment/have-not-filled/fellowship`
-                    )
-                  }}
-                  number={council?.fellowshipEquipmentNotFilledCount}
-                  color="text-danger"
-                />
-              </Col>
-              <Col>
-                <DefaultersMenuButton
-                  name="Filled"
-                  onClick={() => {}}
-                  number={council?.fellowshipEquipmentFilledCount}
-                  color="text-success"
-                />
-              </Col>
-            </Row>
-          </div>
-          <div className=" gap-2 mt-4">
-            <h6>
-              Constituencies :{' '}
-              <span className="text-primary">{council?.constituencyCount}</span>
-            </h6>
-            <Row className="mt-3">
-              <Col>
-                <DefaultersMenuButton
-                  name="Have not filled"
-                  onClick={() => {
-                    navigate(
-                      `/campaigns/council/equipment/have-not-filled/constituency`
-                    )
-                  }}
-                  number={council?.constituencyEquipmentNotFilledCount}
-                  color="text-danger"
-                />
-              </Col>
-              <Col>
-                <DefaultersMenuButton
-                  name="Filled"
-                  onClick={() => {}}
-                  number={council?.constituencyEquipmentFilledCount}
-                  color="text-success"
-                />
-              </Col>
-            </Row>
-          </div>
-        </Container>
-      </div>
-    </ApolloWrapper>
+            <div className=" gap-2 mt-4">
+              <h6>
+                Fellowships :{' '}
+                <span className="text-primary">{council?.fellowshipCount}</span>
+              </h6>
+              <Row className="mt-3">
+                <Col>
+                  <DefaultersMenuButton
+                    name="Have not filled"
+                    onClick={() => {
+                      navigate(
+                        `/campaigns/council/equipment/have-not-filled/fellowship`
+                      )
+                    }}
+                    number={council?.fellowshipEquipmentNotFilledCount}
+                    color="text-danger"
+                  />
+                </Col>
+                <Col>
+                  <DefaultersMenuButton
+                    name="Filled"
+                    onClick={() => {}}
+                    number={council?.fellowshipEquipmentFilledCount}
+                    color="text-success"
+                  />
+                </Col>
+              </Row>
+            </div>
+            <div className=" gap-2 mt-4">
+              <h6>
+                Constituencies :{' '}
+                <span className="text-primary">
+                  {council?.constituencyCount}
+                </span>
+              </h6>
+              <Row className="mt-3">
+                <Col>
+                  <DefaultersMenuButton
+                    name="Have not filled"
+                    onClick={() => {
+                      navigate(
+                        `/campaigns/council/equipment/have-not-filled/constituency`
+                      )
+                    }}
+                    number={council?.constituencyEquipmentNotFilledCount}
+                    color="text-danger"
+                  />
+                </Col>
+                <Col>
+                  <DefaultersMenuButton
+                    name="Filled"
+                    onClick={() => {}}
+                    number={council?.constituencyEquipmentFilledCount}
+                    color="text-success"
+                  />
+                </Col>
+              </Row>
+            </div>
+          </Container>
+        </div>
+      </ApolloWrapper>
+    </PullToRefresh>
   )
 }
 

--- a/web-react-ts/src/pages/campaigns/equipment/council/CouncilEquipmentHaveNotFilledByConstituency.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/council/CouncilEquipmentHaveNotFilledByConstituency.tsx
@@ -10,6 +10,7 @@ import { COUNCIL_EQUIPMENT_DEFAULTERS_LIST_BY_CONSTITUENCY } from 'pages/campaig
 import ApolloWrapper from 'components/base-component/ApolloWrapper'
 import { HeadingPrimary } from 'components/HeadingPrimary/HeadingPrimary'
 import HeadingSecondary from 'components/HeadingSecondary'
+import PullToRefresh from 'react-simple-pull-to-refresh'
 
 function CouncilEquipmentHaveNotFilledByConstituency() {
   const { currentUser } = useContext(MemberContext)
@@ -18,7 +19,7 @@ function CouncilEquipmentHaveNotFilledByConstituency() {
   const churchType = currentUser.currentChurch?.__typename
   const { councilId } = useContext(ChurchContext)
 
-  const { data, loading, error } = useQuery(
+  const { data, loading, error, refetch } = useQuery(
     COUNCIL_EQUIPMENT_DEFAULTERS_LIST_BY_CONSTITUENCY,
     {
       variables: {
@@ -30,29 +31,31 @@ function CouncilEquipmentHaveNotFilledByConstituency() {
   const defaulters = data?.councils[0]?.constituencyEquipmentNotFilled
 
   return (
-    <ApolloWrapper data={data} loading={loading} error={error}>
-      <div className="d-flex align-items-center justify-content-center ">
-        <Container>
-          <div className="text-center">
-            <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
-            <HeadingSecondary>Equipment Campaign</HeadingSecondary>
-          </div>
-          <h6 className="mt-4">
-            Constituencies that haven't filled their form
-          </h6>
-
+    <PullToRefresh onRefresh={() => refetch({ councilId: councilId })}>
+      <ApolloWrapper data={data} loading={loading} error={error}>
+        <div className="d-flex align-items-center justify-content-center ">
           <Container>
-            <Row>
-              {defaulters?.map(
-                (defaulter: EquipmentDefaulterProps, index: number) => (
-                  <DefaultersCard key={index} defaulter={defaulter} />
-                )
-              )}
-            </Row>
+            <div className="text-center">
+              <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
+              <HeadingSecondary>Equipment Campaign</HeadingSecondary>
+            </div>
+            <h6 className="mt-4">
+              Constituencies that haven't filled their form
+            </h6>
+
+            <Container>
+              <Row>
+                {defaulters?.map(
+                  (defaulter: EquipmentDefaulterProps, index: number) => (
+                    <DefaultersCard key={index} defaulter={defaulter} />
+                  )
+                )}
+              </Row>
+            </Container>
           </Container>
-        </Container>
-      </div>
-    </ApolloWrapper>
+        </div>
+      </ApolloWrapper>
+    </PullToRefresh>
   )
 }
 

--- a/web-react-ts/src/pages/campaigns/equipment/council/CouncilEquipmentHaveNotFilledByFellowship.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/council/CouncilEquipmentHaveNotFilledByFellowship.tsx
@@ -10,6 +10,7 @@ import { COUNCIL_EQUIPMENT_DEFAULTERS_LIST_BY_FELLOWSHIP } from 'pages/campaigns
 import ApolloWrapper from 'components/base-component/ApolloWrapper'
 import { HeadingPrimary } from 'components/HeadingPrimary/HeadingPrimary'
 import HeadingSecondary from 'components/HeadingSecondary'
+import PullToRefresh from 'react-simple-pull-to-refresh'
 
 const CouncilEquipmentHaveNotFilledByFellowship = () => {
   const { currentUser } = useContext(MemberContext)
@@ -18,7 +19,7 @@ const CouncilEquipmentHaveNotFilledByFellowship = () => {
   const churchType = currentUser.currentChurch?.__typename
   const { councilId } = useContext(ChurchContext)
 
-  const { data, loading, error } = useQuery(
+  const { data, loading, error, refetch } = useQuery(
     COUNCIL_EQUIPMENT_DEFAULTERS_LIST_BY_FELLOWSHIP,
     {
       variables: {
@@ -30,27 +31,29 @@ const CouncilEquipmentHaveNotFilledByFellowship = () => {
   const defaulters = data?.councils[0]?.fellowshipEquipmentNotFilled
 
   return (
-    <ApolloWrapper data={data} loading={loading} error={error}>
-      <div className="d-flex align-items-center justify-content-center ">
-        <Container>
-          <div className="text-center">
-            <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
-            <HeadingSecondary>Equipment Campaign</HeadingSecondary>
-          </div>
-          <h6 className="mt-4">Fellowships that haven't filled their form</h6>
-
+    <PullToRefresh onRefresh={() => refetch({ councilId: councilId })}>
+      <ApolloWrapper data={data} loading={loading} error={error}>
+        <div className="d-flex align-items-center justify-content-center ">
           <Container>
-            <Row>
-              {defaulters?.map(
-                (defaulter: EquipmentDefaulterProps, index: number) => (
-                  <DefaultersCard key={index} defaulter={defaulter} />
-                )
-              )}
-            </Row>
+            <div className="text-center">
+              <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
+              <HeadingSecondary>Equipment Campaign</HeadingSecondary>
+            </div>
+            <h6 className="mt-4">Fellowships that haven't filled their form</h6>
+
+            <Container>
+              <Row>
+                {defaulters?.map(
+                  (defaulter: EquipmentDefaulterProps, index: number) => (
+                    <DefaultersCard key={index} defaulter={defaulter} />
+                  )
+                )}
+              </Row>
+            </Container>
           </Container>
-        </Container>
-      </div>
-    </ApolloWrapper>
+        </div>
+      </ApolloWrapper>
+    </PullToRefresh>
   )
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Implemented Pull to Refresh feature on Equipment Defaulters pages so that a user can refresh the defaulters pages with new data in the PWA

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
yes I have tested on my local machine  

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/Videos (if appropriate):

<!--Not optional. Please oblige so that your PR will be merged in due time!-->
