### PR TITLE
feat: implement equipment defaulters flow for gathering and stream le…

### DIFF
--- a/web-react-ts/src/pages/campaigns/CampaignQueries.ts
+++ b/web-react-ts/src/pages/campaigns/CampaignQueries.ts
@@ -73,6 +73,49 @@ export const EQUIPMENT_END_DATE = gql`
   }
 `
 
+export const GATHERING_SERVICE_EQUIPMENT_DEFAULTERS_NUMBER_BY_CONSTITUENCY_AND_FELLOWSHIP = gql`
+  query gatheringServiceEquipmentDefaultersNumberByConstituencyAndFellowship(
+    $gatheringServiceId: ID
+  ) {
+    gatheringServices(where: { id: $gatheringServiceId }) {
+      id
+      constituencyCount
+      constituencyEquipmentFilledCount
+      constituencyEquipmentNotFilledCount
+      fellowshipCount
+      fellowshipEquipmentFilledCount
+      fellowshipEquipmentNotFilledCount
+      streamCount
+    }
+  }
+`
+
+export const GATHERING_SERVICE_BY_STREAM_EQUIPMENT_DEFAULTERS = gql`
+  query equipmentGatheringServiceByStreamDefaulters($gatheringServiceId: ID) {
+    gatheringServices(where: { id: $gatheringServiceId }) {
+      id
+      name
+      streams {
+        id
+        name
+        constituencyCount
+        fellowshipCount
+        constituencyEquipmentFilledCount
+        constituencyEquipmentNotFilledCount
+        fellowshipEquipmentFilledCount
+        fellowshipEquipmentNotFilledCount
+        admin {
+          id
+          firstName
+          lastName
+          whatsappNumber
+          phoneNumber
+        }
+      }
+    }
+  }
+`
+
 //Streams Queries and Mutations
 export const STREAM_CAMPAIGN_LIST = gql`
   query streamCampaigns($streamId: ID) {
@@ -116,6 +159,48 @@ export const STREAM_BY_COUNCIL = gql`
         fellowshipCount
         constituencyCount
       }
+    }
+  }
+`
+export const STREAM_BY_COUNCIL_EQUIPMENT_DEFAULTERS = gql`
+  query equipmentStreamByCouncilDefaulters($streamId: ID) {
+    streams(where: { id: $streamId }) {
+      id
+      name
+      councils {
+        id
+        name
+        constituencyCount
+        fellowshipCount
+        constituencyEquipmentFilledCount
+        constituencyEquipmentNotFilledCount
+        fellowshipEquipmentFilledCount
+        fellowshipEquipmentNotFilledCount
+        admin {
+          id
+          firstName
+          lastName
+          whatsappNumber
+          phoneNumber
+        }
+      }
+    }
+  }
+`
+
+export const STREAM_EQUIPMENT_DEFAULTERS_NUMBER_BY_CONSTITUENCY_AND_FELLOWSHIP = gql`
+  query streamEquipmentDefaultersNumberByConstituencyAndFellowship(
+    $streamId: ID
+  ) {
+    streams(where: { id: $streamId }) {
+      id
+      constituencyCount
+      constituencyEquipmentFilledCount
+      constituencyEquipmentNotFilledCount
+      fellowshipCount
+      fellowshipEquipmentFilledCount
+      fellowshipEquipmentNotFilledCount
+      councilCount
     }
   }
 `
@@ -196,6 +281,32 @@ export const COUNCIL_EQUIPMENT_DEFAULTERS_LIST_BY_FELLOWSHIP = gql`
           lastName
           phoneNumber
           whatsappNumber
+        }
+      }
+    }
+  }
+`
+export const COUNCIL_BY_CONSTITUENCY_EQUIPMENT_DEFAULTERS = gql`
+  query equipmentCouncilByConstituencyDefaulters($councilId: ID) {
+    councils(where: { id: $councilId }) {
+      id
+      name
+      constituencies {
+        id
+        name
+        fellowshipCount
+        fellowshipEquipmentFilledCount
+        fellowshipEquipmentNotFilledCount
+        equipmentRecord {
+          id
+          pulpits
+        }
+        admin {
+          id
+          firstName
+          lastName
+          whatsappNumber
+          phoneNumber
         }
       }
     }
@@ -298,6 +409,7 @@ export const CONSTITUENCY_EQUIPMENT_DEFAULTERS_NUMBER_BY_FELLOWSHIP = gql`
   query equipmentConstituencyDefaultersNumberByFellowship($constituencyId: ID) {
     constituencies(where: { id: $constituencyId }) {
       id
+      name
       fellowshipEquipmentFilledCount
       fellowshipEquipmentNotFilledCount
       fellowshipCount

--- a/web-react-ts/src/pages/campaigns/campaignsRoutes.ts
+++ b/web-react-ts/src/pages/campaigns/campaignsRoutes.ts
@@ -51,6 +51,11 @@ import CouncilEquipmentDefaulters from './equipment/council/CouncilEquipmentDefa
 import CouncilEquipmentHaveNotFilledByFellowship from './equipment/council/CouncilEquipmentHaveNotFilledByFellowship'
 import CouncilEquipmentHaveNotFilledByConstituency from './equipment/council/CouncilEquipmentHaveNotFilledByConstituency'
 import { RouteTypes } from 'global-types'
+import GatheringServiceEquipmentDefaulters from './equipment/gathering-service/GatheringServiceEquipmentDefaulters'
+import GatheringServiceByStreamEquipmentDefaulters from './equipment/gathering-service/GatheringServiceByStreamEquipmentDefaulters'
+import StreamByCouncilEquipmentDefaulters from './equipment/stream/StreamByCouncilEquipmentDefaulters'
+import CouncilByConstituencyEquipmentDefaulters from './equipment/council/CouncilByConstituencyEquipmentDefaulters'
+import StreamEquipmentDefaulters from './equipment/stream/StreamEquipmentDefaulters'
 
 export const campaigns: RouteTypes[] = [
   //gathering-service routes
@@ -108,6 +113,18 @@ export const campaigns: RouteTypes[] = [
     roles: permitLeaderAdmin('GatheringService'),
     placeholder: true,
   },
+  {
+    path: '/campaigns/gathering-service/equipment/defaulters',
+    element: GatheringServiceEquipmentDefaulters,
+    roles: permitAdmin('GatheringService'),
+    placeholder: true,
+  },
+  {
+    path: '/campaigns/gathering-service/stream/equipment/defaulters',
+    element: GatheringServiceByStreamEquipmentDefaulters,
+    roles: permitAdmin('GatheringService'),
+    placeholder: true,
+  },
 
   //stream routes
   {
@@ -156,6 +173,18 @@ export const campaigns: RouteTypes[] = [
     path: '/campaigns/stream/telepastoring',
     element: StreamTelepastoringCampaign,
     roles: permitLeaderAdmin('Stream'),
+    placeholder: true,
+  },
+  {
+    path: '/campaigns/stream/council/equipment/defaulters',
+    element: StreamByCouncilEquipmentDefaulters,
+    roles: permitAdmin('Stream'),
+    placeholder: true,
+  },
+  {
+    path: '/campaigns/stream/equipment/defaulters',
+    element: StreamEquipmentDefaulters,
+    roles: permitAdmin('Stream'),
     placeholder: true,
   },
 
@@ -223,6 +252,12 @@ export const campaigns: RouteTypes[] = [
   {
     path: '/campaigns/council/equipment/have-not-filled/constituency',
     element: CouncilEquipmentHaveNotFilledByConstituency,
+    roles: permitAdmin('Council'),
+    placeholder: true,
+  },
+  {
+    path: '/campaigns/council/constituency/equipment/defaulters',
+    element: CouncilByConstituencyEquipmentDefaulters,
     roles: permitAdmin('Council'),
     placeholder: true,
   },

--- a/web-react-ts/src/pages/campaigns/components/buttons/DefaulterDetailsCard.tsx
+++ b/web-react-ts/src/pages/campaigns/components/buttons/DefaulterDetailsCard.tsx
@@ -1,0 +1,108 @@
+import { ChurchContext } from 'contexts/ChurchContext'
+import { EquipmentRecord } from 'global-types'
+import React, { useContext } from 'react'
+import { Card, Button } from 'react-bootstrap'
+import { TelephoneFill, Whatsapp } from 'react-bootstrap-icons'
+import { useNavigate } from 'react-router'
+
+type Admin = {
+  firstName: string
+  lastName: string
+  whatsappNumber: string
+  phoneNumber: string
+}
+
+export type EquipmentDefaulters = {
+  constituencyCount: number
+  constituencyEquipmentFilledCount: number
+  constituencyEquipmentNotFilledCount: number
+  fellowshipCount: number
+  fellowshipEquipmentFilledCount: number
+  fellowshipEquipmentNotFilledCount: number
+  id: string
+  name: string
+  admin: Admin
+  equipmentRecord: EquipmentRecord
+  __typename: string
+}
+
+type DefaulterDetailsCardProps = {
+  church: EquipmentDefaulters
+  route: string
+}
+
+function DefaulterDetailsCard(props: DefaulterDetailsCardProps) {
+  const church = props?.church
+  const { clickCard } = useContext(ChurchContext)
+  const navigate = useNavigate()
+
+  return (
+    <Card className="mt-2">
+      <Card.Header className="fw-bold">{`${church?.name} ${church?.__typename}`}</Card.Header>
+      <Card.Body
+        onClick={() => {
+          clickCard(church)
+          props.route === 'constituency/fellowship'
+            ? navigate('/campaigns/constituency/equipment/defaulters')
+            : navigate(`/campaigns/${props.route}/equipment/defaulters`)
+        }}
+      >
+        <div className="fw-bold">
+          Fellowship Count: {church?.fellowshipCount}
+        </div>
+        {props.route === 'constituency/fellowship' ? null : (
+          <div className="fw-bold">
+            Constituency Count: {church?.constituencyCount}
+          </div>
+        )}
+
+        <div className="text-success">
+          Fellowship Filled Count: {church?.fellowshipEquipmentFilledCount}
+        </div>
+        {props.route === 'constituency/fellowship' ? (
+          <div className="text-success">
+            Constituency Filled:{' '}
+            {church.equipmentRecord.pulpits === null ? 'No' : 'Yes'}
+          </div>
+        ) : (
+          <div className="text-success">
+            Constituency Filled Count:{' '}
+            {church?.constituencyEquipmentFilledCount}
+          </div>
+        )}
+
+        <div className="text-danger">
+          Fellowship Not Filled Count:{' '}
+          {church?.fellowshipEquipmentNotFilledCount}
+        </div>
+        {props.route === 'constituency/fellowship' ? null : (
+          <div className="text-danger">
+            Constituency Not Filled Count:{' '}
+            {church?.constituencyEquipmentNotFilledCount}
+          </div>
+        )}
+      </Card.Body>
+      <Card.Footer>
+        <div className="mb-2">
+          Contact Admin:{' '}
+          {`${church?.admin?.firstName} ${church?.admin?.lastName}`}{' '}
+        </div>
+        <a href={`tel:${church?.admin?.phoneNumber}`}>
+          <Button variant="primary">
+            <TelephoneFill /> Call
+          </Button>
+        </a>
+        <a
+          href={`https://wa.me/${church?.admin?.whatsappNumber}`}
+          className="ms-3"
+        >
+          <Button variant="success">
+            <Whatsapp /> WhatsApp
+          </Button>
+        </a>
+      </Card.Footer>
+    </Card>
+  )
+}
+
+export default DefaulterDetailsCard

--- a/web-react-ts/src/pages/campaigns/components/buttons/DefaultersMenuButton.tsx
+++ b/web-react-ts/src/pages/campaigns/components/buttons/DefaultersMenuButton.tsx
@@ -7,7 +7,7 @@ type Props = {
   name: string
   number: number
   color: string
-  onClick: () => void
+  onClick?: () => void
 }
 
 const DefaultersMenuButton = (props: Props) => {

--- a/web-react-ts/src/pages/campaigns/equipment/constituency/ConstituencyEquipmentDefaulters.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/constituency/ConstituencyEquipmentDefaulters.tsx
@@ -2,7 +2,6 @@ import ApolloWrapper from 'components/base-component/ApolloWrapper'
 import DefaultersMenuButton from 'pages/campaigns/components/buttons/DefaultersMenuButton'
 import React, { useContext } from 'react'
 import { Col, Container, Row } from 'react-bootstrap'
-import { MemberContext } from 'contexts/MemberContext'
 import { useNavigate } from 'react-router'
 import { ChurchContext } from 'contexts/ChurchContext'
 import { useQuery } from '@apollo/client'
@@ -12,11 +11,8 @@ import HeadingSecondary from 'components/HeadingSecondary'
 import PullToRefresh from 'react-simple-pull-to-refresh'
 
 function ConstituencyEquipmentDefaulters() {
-  const { currentUser } = useContext(MemberContext)
   const navigate = useNavigate()
 
-  const church = currentUser.currentChurch
-  const churchType = currentUser.currentChurch?.__typename
   const { constituencyId } = useContext(ChurchContext)
 
   const { data, loading, error, refetch } = useQuery(
@@ -37,7 +33,7 @@ function ConstituencyEquipmentDefaulters() {
         <div className="d-flex align-items-center justify-content-center ">
           <Container>
             <div className="text-center">
-              <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
+              <HeadingPrimary>{`${constituency?.name} Constituency`}</HeadingPrimary>
               <HeadingSecondary>Equipment Campaign</HeadingSecondary>
             </div>
             <h6 className="mt-4">Fellowships that haven't filled their form</h6>

--- a/web-react-ts/src/pages/campaigns/equipment/council/CouncilByConstituencyEquipmentDefaulters.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/council/CouncilByConstituencyEquipmentDefaulters.tsx
@@ -1,0 +1,58 @@
+import { useQuery } from '@apollo/client'
+import ApolloWrapper from 'components/base-component/ApolloWrapper'
+import { HeadingPrimary } from 'components/HeadingPrimary/HeadingPrimary'
+import HeadingSecondary from 'components/HeadingSecondary'
+import { ChurchContext } from 'contexts/ChurchContext'
+import { COUNCIL_BY_CONSTITUENCY_EQUIPMENT_DEFAULTERS } from 'pages/campaigns/CampaignQueries'
+import DefaulterDetailsCard, {
+  EquipmentDefaulters,
+} from 'pages/campaigns/components/buttons/DefaulterDetailsCard'
+import React, { useContext } from 'react'
+import { Container, Row } from 'react-bootstrap'
+
+const CouncilByConstituencyEquipmentDefaulters = () => {
+  const { councilId } = useContext(ChurchContext)
+
+  const { data, loading, error } = useQuery(
+    COUNCIL_BY_CONSTITUENCY_EQUIPMENT_DEFAULTERS,
+    {
+      variables: {
+        councilId: councilId,
+      },
+    }
+  )
+  const council = data?.councils[0]
+  const constituencies = council?.constituencies
+
+  return (
+    <ApolloWrapper data={data} loading={loading} error={error}>
+      <div className="d-flex align-items-center justify-content-center ">
+        <Container>
+          <div className="text-center">
+            <HeadingPrimary>{`${council?.name} Council`}</HeadingPrimary>
+            <HeadingSecondary>Equipment Campaign</HeadingSecondary>
+          </div>
+          <h6 className="mt-4">
+            Fellowships and Constituencies that haven't filled their form
+          </h6>
+
+          <Container>
+            <Row>
+              {constituencies?.map(
+                (constituency: EquipmentDefaulters, index: number) => (
+                  <DefaulterDetailsCard
+                    key={index}
+                    church={constituency}
+                    route={'constituency/fellowship'}
+                  />
+                )
+              )}
+            </Row>
+          </Container>
+        </Container>
+      </div>
+    </ApolloWrapper>
+  )
+}
+
+export default CouncilByConstituencyEquipmentDefaulters

--- a/web-react-ts/src/pages/campaigns/equipment/council/CouncilEquipmentDefaulters.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/council/CouncilEquipmentDefaulters.tsx
@@ -17,7 +17,7 @@ const CouncilEquipmentDefaulters = () => {
 
   const church = currentUser.currentChurch
   const churchType = currentUser.currentChurch?.__typename
-  const { councilId } = useContext(ChurchContext)
+  const { councilId, clickCard } = useContext(ChurchContext)
 
   const { data, loading, error, refetch } = useQuery(
     COUNCIL_EQUIPMENT_DEFAULTERS_NUMBER_BY_CONSTITUENCY_AND_FELLOWSHIP,
@@ -41,6 +41,15 @@ const CouncilEquipmentDefaulters = () => {
             <h6 className="mt-4">
               Fellowships and Constituencies that haven't filled their form
             </h6>
+            <DefaultersMenuButton
+              name="Constituencies"
+              onClick={() => {
+                clickCard(council)
+                navigate('/campaigns/council/constituency/equipment/defaulters')
+              }}
+              number={council?.constituencyCount}
+              color="text-danger"
+            />
             <div className=" gap-2 mt-4">
               <h6>
                 Fellowships :{' '}

--- a/web-react-ts/src/pages/campaigns/equipment/gathering-service/GatheringServiceByStreamEquipmentDefaulters.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/gathering-service/GatheringServiceByStreamEquipmentDefaulters.tsx
@@ -1,0 +1,60 @@
+import { useQuery } from '@apollo/client'
+import ApolloWrapper from 'components/base-component/ApolloWrapper'
+import { HeadingPrimary } from 'components/HeadingPrimary/HeadingPrimary'
+import HeadingSecondary from 'components/HeadingSecondary'
+import { ChurchContext } from 'contexts/ChurchContext'
+import { MemberContext } from 'contexts/MemberContext'
+import { GATHERING_SERVICE_BY_STREAM_EQUIPMENT_DEFAULTERS } from 'pages/campaigns/CampaignQueries'
+import DefaulterDetailsCard, {
+  EquipmentDefaulters,
+} from 'pages/campaigns/components/buttons/DefaulterDetailsCard'
+import React, { useContext } from 'react'
+import { Container, Row } from 'react-bootstrap'
+
+const GatheringServiceByStreamEquipmentDefaulters = () => {
+  const { currentUser } = useContext(MemberContext)
+
+  const church = currentUser.currentChurch
+  const { gatheringServiceId } = useContext(ChurchContext)
+
+  const { data, loading, error } = useQuery(
+    GATHERING_SERVICE_BY_STREAM_EQUIPMENT_DEFAULTERS,
+    {
+      variables: {
+        gatheringServiceId: gatheringServiceId,
+      },
+    }
+  )
+  const gatheringService = data?.gatheringServices[0]
+  const streams = gatheringService?.streams
+
+  return (
+    <ApolloWrapper data={data} loading={loading} error={error}>
+      <div className="d-flex align-items-center justify-content-center ">
+        <Container>
+          <div className="text-center">
+            <HeadingPrimary>{`${church?.name} Gathering Service`}</HeadingPrimary>
+            <HeadingSecondary>Equipment Campaign</HeadingSecondary>
+          </div>
+          <h6 className="mt-4">
+            Fellowships and Constituencies that haven't filled their form
+          </h6>
+
+          <Container>
+            <Row>
+              {streams?.map((stream: EquipmentDefaulters, index: number) => (
+                <DefaulterDetailsCard
+                  key={index}
+                  church={stream}
+                  route={'stream/council'}
+                />
+              ))}
+            </Row>
+          </Container>
+        </Container>
+      </div>
+    </ApolloWrapper>
+  )
+}
+
+export default GatheringServiceByStreamEquipmentDefaulters

--- a/web-react-ts/src/pages/campaigns/equipment/gathering-service/GatheringServiceEquipmentCampaign.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/gathering-service/GatheringServiceEquipmentCampaign.tsx
@@ -9,6 +9,8 @@ import { EQUIPMENT_END_DATE } from 'pages/campaigns/CampaignQueries'
 import { useQuery } from '@apollo/client'
 import { getHumanReadableDate } from 'jd-date-utils'
 import Placeholder from '../../../../components/Placeholder'
+import RoleView from 'auth/RoleView'
+import { permitAdmin } from 'permission-utils'
 
 const GatheringServiceEquipmentCampaign = () => {
   const { currentUser } = useContext(MemberContext)
@@ -50,6 +52,14 @@ const GatheringServiceEquipmentCampaign = () => {
               navigate(`/campaigns/gathering-service/set-equipment-deadline`)
             }
           />
+          <RoleView roles={permitAdmin('GatheringService')}>
+            <MenuButton
+              name="Defaulters"
+              onClick={() =>
+                navigate('/campaigns/gathering-service/equipment/defaulters')
+              }
+            />
+          </RoleView>
         </div>
       </Container>
     </div>

--- a/web-react-ts/src/pages/campaigns/equipment/gathering-service/GatheringServiceEquipmentDefaulters.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/gathering-service/GatheringServiceEquipmentDefaulters.tsx
@@ -1,0 +1,112 @@
+import DefaultersMenuButton from 'pages/campaigns/components/buttons/DefaultersMenuButton'
+import React, { useContext } from 'react'
+import { Col, Container, Row } from 'react-bootstrap'
+import { MemberContext } from 'contexts/MemberContext'
+import { useNavigate } from 'react-router'
+import { ChurchContext } from 'contexts/ChurchContext'
+import { useQuery } from '@apollo/client'
+import { GATHERING_SERVICE_EQUIPMENT_DEFAULTERS_NUMBER_BY_CONSTITUENCY_AND_FELLOWSHIP } from 'pages/campaigns/CampaignQueries'
+import ApolloWrapper from 'components/base-component/ApolloWrapper'
+import { HeadingPrimary } from 'components/HeadingPrimary/HeadingPrimary'
+import HeadingSecondary from 'components/HeadingSecondary'
+
+const GatheringServiceEquipmentDefaulters = () => {
+  const { currentUser } = useContext(MemberContext)
+  const navigate = useNavigate()
+
+  const church = currentUser.currentChurch
+
+  const { gatheringServiceId, clickCard } = useContext(ChurchContext)
+
+  const { data, loading, error } = useQuery(
+    GATHERING_SERVICE_EQUIPMENT_DEFAULTERS_NUMBER_BY_CONSTITUENCY_AND_FELLOWSHIP,
+    {
+      variables: {
+        gatheringServiceId: gatheringServiceId,
+      },
+    }
+  )
+  const gatheringService = data?.gatheringServices[0]
+
+  return (
+    <ApolloWrapper data={data} loading={loading} error={error}>
+      <div className="d-flex align-items-center justify-content-center ">
+        <Container>
+          <div className="text-center">
+            <HeadingPrimary>{`${church?.name} Gathering Service`}</HeadingPrimary>
+            <HeadingSecondary>Equipment Campaign</HeadingSecondary>
+          </div>
+          <h6 className="mt-4">
+            Fellowships and Constituencies that haven't filled their form
+          </h6>
+          <DefaultersMenuButton
+            name="Streams"
+            onClick={() => {
+              clickCard(gatheringService)
+              navigate(
+                '/campaigns/gathering-service/stream/equipment/defaulters'
+              )
+            }}
+            number={gatheringService?.streamCount}
+            color="text-danger"
+          />
+          <div className=" gap-2 mt-4">
+            <h6>
+              Fellowships :{' '}
+              <span className="text-primary">
+                {gatheringService?.fellowshipCount}
+              </span>
+            </h6>
+
+            <Row className="mt-3">
+              <Col>
+                <DefaultersMenuButton
+                  name="Have not filled"
+                  onClick={() => undefined}
+                  number={gatheringService?.fellowshipEquipmentNotFilledCount}
+                  color="text-danger"
+                />
+              </Col>
+              <Col>
+                <DefaultersMenuButton
+                  name="Filled"
+                  onClick={() => {}}
+                  number={gatheringService?.fellowshipEquipmentFilledCount}
+                  color="text-success"
+                />
+              </Col>
+            </Row>
+          </div>
+          <div className=" gap-2 mt-4">
+            <h6>
+              Constituencies :{' '}
+              <span className="text-primary">
+                {gatheringService?.constituencyCount}
+              </span>
+            </h6>
+            <Row className="mt-3">
+              <Col>
+                <DefaultersMenuButton
+                  name="Have not filled"
+                  onClick={() => undefined}
+                  number={gatheringService?.constituencyEquipmentNotFilledCount}
+                  color="text-danger"
+                />
+              </Col>
+              <Col>
+                <DefaultersMenuButton
+                  name="Filled"
+                  onClick={() => {}}
+                  number={gatheringService?.constituencyEquipmentFilledCount}
+                  color="text-success"
+                />
+              </Col>
+            </Row>
+          </div>
+        </Container>
+      </div>
+    </ApolloWrapper>
+  )
+}
+
+export default GatheringServiceEquipmentDefaulters

--- a/web-react-ts/src/pages/campaigns/equipment/stream/StreamByCouncilEquipmentDefaulters.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/stream/StreamByCouncilEquipmentDefaulters.tsx
@@ -1,0 +1,56 @@
+import { useQuery } from '@apollo/client'
+import ApolloWrapper from 'components/base-component/ApolloWrapper'
+import { HeadingPrimary } from 'components/HeadingPrimary/HeadingPrimary'
+import HeadingSecondary from 'components/HeadingSecondary'
+import { ChurchContext } from 'contexts/ChurchContext'
+import { STREAM_BY_COUNCIL_EQUIPMENT_DEFAULTERS } from 'pages/campaigns/CampaignQueries'
+import DefaulterDetailsCard, {
+  EquipmentDefaulters,
+} from 'pages/campaigns/components/buttons/DefaulterDetailsCard'
+import React, { useContext } from 'react'
+import { Container, Row } from 'react-bootstrap'
+
+const StreamByCouncilEquipmentDefaulters = () => {
+  const { streamId } = useContext(ChurchContext)
+
+  const { data, loading, error } = useQuery(
+    STREAM_BY_COUNCIL_EQUIPMENT_DEFAULTERS,
+    {
+      variables: {
+        streamId: streamId,
+      },
+    }
+  )
+  const stream = data?.streams[0]
+  const councils = stream?.councils
+
+  return (
+    <ApolloWrapper data={data} loading={loading} error={error}>
+      <div className="d-flex align-items-center justify-content-center ">
+        <Container>
+          <div className="text-center">
+            <HeadingPrimary>{`${stream?.name} Stream`}</HeadingPrimary>
+            <HeadingSecondary>Equipment Campaign</HeadingSecondary>
+          </div>
+          <h6 className="mt-4">
+            Fellowships and Constituencies that haven't filled their form
+          </h6>
+
+          <Container>
+            <Row>
+              {councils?.map((council: EquipmentDefaulters, index: number) => (
+                <DefaulterDetailsCard
+                  key={index}
+                  church={council}
+                  route={'council/constituency'}
+                />
+              ))}
+            </Row>
+          </Container>
+        </Container>
+      </div>
+    </ApolloWrapper>
+  )
+}
+
+export default StreamByCouncilEquipmentDefaulters

--- a/web-react-ts/src/pages/campaigns/equipment/stream/StreamEquipmentCampaign.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/stream/StreamEquipmentCampaign.tsx
@@ -9,6 +9,8 @@ import { EQUIPMENT_END_DATE } from 'pages/campaigns/CampaignQueries'
 import { useQuery } from '@apollo/client'
 import { getHumanReadableDate } from 'jd-date-utils'
 import Placeholder from '../../../../components/Placeholder'
+import { permitAdmin } from 'permission-utils'
+import RoleView from 'auth/RoleView'
 
 const StreamEquipmentCampaign = () => {
   const { currentUser } = useContext(MemberContext)
@@ -43,6 +45,12 @@ const StreamEquipmentCampaign = () => {
             name="View Trends"
             onClick={() => navigate(`/campaigns/stream/equipment/trends`)}
           />
+          <RoleView roles={permitAdmin('Stream')}>
+            <MenuButton
+              name="Defaulters"
+              onClick={() => navigate('/campaigns/stream/equipment/defaulters')}
+            />
+          </RoleView>
         </div>
       </Container>
     </div>

--- a/web-react-ts/src/pages/campaigns/equipment/stream/StreamEquipmentDefaulters.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/stream/StreamEquipmentDefaulters.tsx
@@ -1,0 +1,105 @@
+import DefaultersMenuButton from 'pages/campaigns/components/buttons/DefaultersMenuButton'
+import React, { useContext } from 'react'
+import { Col, Container, Row } from 'react-bootstrap'
+import { MemberContext } from 'contexts/MemberContext'
+import { useNavigate } from 'react-router'
+import { ChurchContext } from 'contexts/ChurchContext'
+import { useQuery } from '@apollo/client'
+import { STREAM_EQUIPMENT_DEFAULTERS_NUMBER_BY_CONSTITUENCY_AND_FELLOWSHIP } from 'pages/campaigns/CampaignQueries'
+import ApolloWrapper from 'components/base-component/ApolloWrapper'
+import { HeadingPrimary } from 'components/HeadingPrimary/HeadingPrimary'
+import HeadingSecondary from 'components/HeadingSecondary'
+
+const StreamEquipmentDefaulters = () => {
+  const { currentUser } = useContext(MemberContext)
+  const navigate = useNavigate()
+
+  const church = currentUser.currentChurch
+  const churchType = currentUser.currentChurch?.__typename
+  const { streamId, clickCard } = useContext(ChurchContext)
+
+  const { data, loading, error } = useQuery(
+    STREAM_EQUIPMENT_DEFAULTERS_NUMBER_BY_CONSTITUENCY_AND_FELLOWSHIP,
+    {
+      variables: {
+        streamId: streamId,
+      },
+    }
+  )
+  const stream = data?.streams[0]
+
+  return (
+    <ApolloWrapper data={data} loading={loading} error={error}>
+      <div className="d-flex align-items-center justify-content-center ">
+        <Container>
+          <div className="text-center">
+            <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
+            <HeadingSecondary>Equipment Campaign</HeadingSecondary>
+          </div>
+          <h6 className="mt-4">
+            Fellowships and Constituencies that haven't filled their form
+          </h6>
+          <DefaultersMenuButton
+            name="Councils"
+            onClick={() => {
+              clickCard(stream)
+              navigate('/campaigns/stream/council/equipment/defaulters')
+            }}
+            number={stream?.councilCount}
+            color="text-danger"
+          />
+          <div className=" gap-2 mt-4">
+            <h6>
+              Fellowships :{' '}
+              <span className="text-primary">{stream?.fellowshipCount}</span>
+            </h6>
+            <Row className="mt-3">
+              <Col>
+                <DefaultersMenuButton
+                  name="Have not filled"
+                  onClick={() => {}}
+                  number={stream?.fellowshipEquipmentNotFilledCount}
+                  color="text-danger"
+                />
+              </Col>
+              <Col>
+                <DefaultersMenuButton
+                  name="Filled"
+                  onClick={() => {}}
+                  number={stream?.fellowshipEquipmentFilledCount}
+                  color="text-success"
+                />
+              </Col>
+            </Row>
+          </div>
+          <div className=" gap-2 mt-4">
+            <h6>
+              Constituencies :{' '}
+              <span className="text-primary">{stream?.constituencyCount}</span>
+            </h6>
+            <Row className="mt-3">
+              <Col>
+                <DefaultersMenuButton
+                  name="Have not filled"
+                  onClick={() => {}}
+                  number={stream?.constituencyEquipmentNotFilledCount}
+                  color="text-danger"
+                />
+              </Col>
+              <Col>
+                <DefaultersMenuButton
+                  name="Filled"
+                  onClick={() => {}}
+                  number={stream?.constituencyEquipmentFilledCount}
+                  color="text-success"
+                />
+              </Col>
+            </Row>
+          </div>
+        </Container>
+      </div>
+    </ApolloWrapper>
+  )
+}
+
+export default StreamEquipmentDefaulters


### PR DESCRIPTION
…vel admins

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
added a defaulters flow for equipment campaign so that stream and gathering services admins can view fellowships and constituencies that have not filled their forms

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Tested on my local machine

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/Videos (if appropriate):

<!--Not optional. Please oblige so that your PR will be merged in due time!-->
