### PR TITLE
fix: fix equipment deadline to allow users to fill on day of deadline

### DIFF
--- a/api/src/resolvers/campaigns/campaigns-resolver.ts
+++ b/api/src/resolvers/campaigns/campaigns-resolver.ts
@@ -156,6 +156,7 @@ export const campaignsMutation = {
       const currentDate = new Date()
       const startDate = new Date(equipmentCampaign.campaign.equipmentStartDate)
       const endDate = new Date(equipmentCampaign.campaign.equipmentEndDate)
+      endDate.setDate(endDate.getDate() + 1)
 
       if (currentDate < startDate || currentDate > endDate) {
         throwErrorMsg('Equipment Deadline is up')
@@ -225,8 +226,9 @@ export const campaignsMutation = {
       const currentDate = new Date()
       const startDate = new Date(equipmentCampaign.campaign.equipmentStartDate)
       const endDate = new Date(equipmentCampaign.campaign.equipmentEndDate)
+      endDate.setDate(endDate.getDate() + 1)
 
-      if (!(currentDate >= startDate && currentDate <= endDate)) {
+      if (currentDate < startDate || currentDate > endDate) {
         throwErrorMsg('Equipment Deadline is up')
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This PR fixes an error in the date comparison for the equipment deadline, and allows users to fill their equipment forms on the day of the deadline.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
This has been tested on my localhost and proved to be working.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/Videos (if appropriate):

<!--Not optional. Please oblige so that your PR will be merged in due time!-->
