### PR TITLE
feat: use resolver for updating a member fellowship mutation

### DIFF
--- a/api/src/schema/directory-crud.graphql
+++ b/api/src/schema/directory-crud.graphql
@@ -484,17 +484,6 @@ extend type Mutation {
 extend type Mutation {
   UpdateMemberEmail(id: ID!, email: String!): Member
   UpdateMemberFellowship(memberId: ID!, fellowshipId: ID!): Member
-    @cypher(
-      statement: """
-      MATCH (member:Member {id: $memberId})
-      MATCH (fellowship:Fellowship {id: $fellowshipId})
-
-      OPTIONAL MATCH (member)-[previous:BELONGS_TO]-> (:Fellowship)
-      DELETE previous
-      MERGE (member)-[:BELONGS_TO]-> (fellowship)
-      RETURN member
-      """
-    )
 
   UpdateMemberMinistry(memberId: ID!, ministryId: ID!): Member
     @cypher(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This PR changes the update member fellowship mutation into a resolver. It also rewrites the member count and ministry member count queries to be more reusable and applied when a member's fellowship is changed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
This has been tested on my localhost and found to be working

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/Videos (if appropriate):

<!--Not optional. Please oblige so that your PR will be merged in due time!-->
