### PR TITLE
fix: change import of large-number css to where it is used

### DIFF
--- a/web-react-ts/src/pages/arrivals/Arrivals.css
+++ b/web-react-ts/src/pages/arrivals/Arrivals.css
@@ -31,3 +31,7 @@
 .low-opacity {
   opacity: 0.2;
 }
+
+.large-number {
+  font-size: 30px;
+}

--- a/web-react-ts/src/pages/arrivals/ChurchBySubChurch.tsx
+++ b/web-react-ts/src/pages/arrivals/ChurchBySubChurch.tsx
@@ -14,6 +14,7 @@ import {
   ArrivalsUseChurchExt,
   HigherChurchWithArrivals,
 } from './arrivals-types'
+import './Árrivals.css'
 import {
   COUNCIL_BY_CONSTITUENCY_ARRIVALS,
   STREAM_BY_COUNCIL_ARRIVALS,

--- a/web-react-ts/src/pages/services/defaulters/DefaulterCard.tsx
+++ b/web-react-ts/src/pages/services/defaulters/DefaulterCard.tsx
@@ -5,6 +5,7 @@ import { Card, Button } from 'react-bootstrap'
 import { TelephoneFill, Whatsapp } from 'react-bootstrap-icons'
 import { useNavigate } from 'react-router'
 import { FellowshipWithDefaulters } from './defaulters-types'
+import './Defaulters.css'
 
 type DefaulterCardProps = {
   defaulter: FellowshipWithDefaulters

--- a/web-react-ts/src/pages/services/defaulters/DefaulterInfoCard.tsx
+++ b/web-react-ts/src/pages/services/defaulters/DefaulterInfoCard.tsx
@@ -2,6 +2,7 @@ import PlaceholderCustom from 'components/Placeholder'
 import React from 'react'
 import { Card } from 'react-bootstrap'
 import { useNavigate } from 'react-router'
+import './Defaulters.css'
 
 const DefaulterInfoCard = ({
   defaulter,

--- a/web-react-ts/src/pages/services/defaulters/DefaultersDashboard.tsx
+++ b/web-react-ts/src/pages/services/defaulters/DefaultersDashboard.tsx
@@ -10,7 +10,6 @@ import {
   STREAM_DEFAULTERS,
   GATHERINGSERVICE_DEFAULTERS,
 } from './DefaultersQueries'
-import './Defaulters.css'
 import PlaceholderCustom from 'components/Placeholder'
 import DefaulterInfoCard from './DefaulterInfoCard'
 import RoleView from 'auth/RoleView'

--- a/web-react-ts/src/pages/services/defaulters/PlaceholderDefaulterList.tsx
+++ b/web-react-ts/src/pages/services/defaulters/PlaceholderDefaulterList.tsx
@@ -1,6 +1,7 @@
 import PlaceholderCustom from 'components/Placeholder'
 import React from 'react'
 import { Card, Col } from 'react-bootstrap'
+import './Defaulters.css'
 
 const PlaceholderDefaulterList = () => {
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
After implementing code splitting, we realised that some CSS was being imported in files different from where they are actually used. 
This PR corrects that with regards to the CSS property ‘large-number'

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Testing will be done in the deploy preview

## Screenshots/Videos (if appropriate):

<!--Not optional. Please oblige so that your PR will be merged in due time!-->
