### PR TITLE
ADMIN-348 wrap apollo wrapper component over equipment campaign page to ensure the page is not loaded until data is present

### DIFF
--- a/web-react-ts/src/pages/campaigns/equipment/constituency/ConstituencyEquipmentCampaign.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/constituency/ConstituencyEquipmentCampaign.tsx
@@ -15,6 +15,7 @@ import { HeadingPrimary } from 'components/HeadingPrimary/HeadingPrimary'
 import HeadingSecondary from 'components/HeadingSecondary'
 import { getHumanReadableDate } from 'jd-date-utils'
 import Placeholder from '../../../../components/Placeholder'
+import ApolloWrapper from 'components/base-component/ApolloWrapper'
 
 const ConstituencyEquipmentCampaign = () => {
   const { currentUser } = useContext(MemberContext)
@@ -25,7 +26,7 @@ const ConstituencyEquipmentCampaign = () => {
   const { constituencyId } = useContext(ChurchContext)
   const gatheringServiceId = currentUser?.gatheringService
 
-  const { data } = useQuery(CONSTITUENCY_LATEST_EQUIPMENT_RECORD, {
+  const { data, loading } = useQuery(CONSTITUENCY_LATEST_EQUIPMENT_RECORD, {
     variables: {
       constituencyId: constituencyId,
     },
@@ -33,50 +34,61 @@ const ConstituencyEquipmentCampaign = () => {
 
   const constituencyEquipmentRecord = data?.constituencies[0]?.equipmentRecord
 
-  const { data: equipmentEndDateData, loading } = useQuery(EQUIPMENT_END_DATE, {
-    variables: {
-      gatheringServiceId: gatheringServiceId,
-    },
-  })
+  const { data: equipmentEndDateData, loading: equipmentEndDateLoading } =
+    useQuery(EQUIPMENT_END_DATE, {
+      variables: {
+        gatheringServiceId: gatheringServiceId,
+      },
+    })
 
   const equipmentEndDate =
     equipmentEndDateData?.gatheringServices[0]?.equipmentEndDate
 
   return (
-    <div className="d-flex align-items-center justify-content-center ">
-      <Container>
-        <div className="text-center">
-          <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
-          <HeadingSecondary>Equipment Campaign</HeadingSecondary>
-        </div>
-        <Placeholder as="h6" loading={loading} className="text-center">
-          <h6 className="text-danger text-center">
-            Current Deadline : {getHumanReadableDate(equipmentEndDate)}{' '}
-          </h6>
-        </Placeholder>
-        <div className="d-grid gap-2 mt-4 text-center px-4">
-          {constituencyEquipmentRecord?.pulpits === null && (
-            <MenuButton
-              name="Fill Campaign Form"
-              onClick={() => navigate(`/campaigns/constituency/equipment/form`)}
-            />
-          )}
+    <ApolloWrapper loading={loading} data={data}>
+      <div className="d-flex align-items-center justify-content-center ">
+        <Container>
+          <div className="text-center">
+            <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
+            <HeadingSecondary>Equipment Campaign</HeadingSecondary>
+          </div>
+          <Placeholder
+            as="h6"
+            loading={equipmentEndDateLoading}
+            className="text-center"
+          >
+            <h6 className="text-danger text-center">
+              Current Deadline : {getHumanReadableDate(equipmentEndDate)}{' '}
+            </h6>
+          </Placeholder>
+          <div className="d-grid gap-2 mt-4 text-center px-4">
+            {constituencyEquipmentRecord?.pulpits === null && (
+              <MenuButton
+                name="Fill Campaign Form"
+                onClick={() =>
+                  navigate(`/campaigns/constituency/equipment/form`)
+                }
+              />
+            )}
 
-          <MenuButton
-            name="View Trends"
-            onClick={() => navigate(`/campaigns/constituency/equipment/trends`)}
-          />
-          <RoleView roles={permitAdmin('Constituency')}>
             <MenuButton
-              name="Defaulters"
+              name="View Trends"
               onClick={() =>
-                navigate('/campaigns/constituency/equipment/defaulters')
+                navigate(`/campaigns/constituency/equipment/trends`)
               }
             />
-          </RoleView>
-        </div>
-      </Container>
-    </div>
+            <RoleView roles={permitAdmin('Constituency')}>
+              <MenuButton
+                name="Defaulters"
+                onClick={() =>
+                  navigate('/campaigns/constituency/equipment/defaulters')
+                }
+              />
+            </RoleView>
+          </div>
+        </Container>
+      </div>
+    </ApolloWrapper>
   )
 }
 

--- a/web-react-ts/src/pages/campaigns/equipment/fellowship/FellowshipEquipmentCampaign.tsx
+++ b/web-react-ts/src/pages/campaigns/equipment/fellowship/FellowshipEquipmentCampaign.tsx
@@ -13,6 +13,7 @@ import { HeadingPrimary } from 'components/HeadingPrimary/HeadingPrimary'
 import HeadingSecondary from 'components/HeadingSecondary'
 import { getHumanReadableDate } from 'jd-date-utils'
 import Placeholder from '../../../../components/Placeholder'
+import ApolloWrapper from 'components/base-component/ApolloWrapper'
 
 const FellowshipEquipmentCampaign = () => {
   const { currentUser } = useContext(MemberContext)
@@ -23,7 +24,7 @@ const FellowshipEquipmentCampaign = () => {
   const { fellowshipId } = useContext(ChurchContext)
   const gatheringServiceId = currentUser?.gatheringService
 
-  const { data } = useQuery(FELLOWSHIP_LATEST_EQUIPMENT_RECORD, {
+  const { data, loading } = useQuery(FELLOWSHIP_LATEST_EQUIPMENT_RECORD, {
     variables: {
       fellowshipId: fellowshipId,
     },
@@ -31,42 +32,49 @@ const FellowshipEquipmentCampaign = () => {
 
   const fellowshipEquipmentRecord = data?.fellowships[0]?.equipmentRecord
 
-  const { data: equipmentEndDateData, loading } = useQuery(EQUIPMENT_END_DATE, {
-    variables: {
-      gatheringServiceId: gatheringServiceId,
-    },
-  })
+  const { data: equipmentEndDateData, loading: equipmentEndDateLoading } =
+    useQuery(EQUIPMENT_END_DATE, {
+      variables: {
+        gatheringServiceId: gatheringServiceId,
+      },
+    })
 
   const equipmentEndDate =
     equipmentEndDateData?.gatheringServices[0]?.equipmentEndDate
 
   return (
-    <div className="d-flex align-items-center justify-content-center ">
-      <Container>
-        <div className="text-center">
-          <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
-          <HeadingSecondary>Equipment Campaign</HeadingSecondary>
-        </div>
-        <Placeholder as="h6" loading={loading} className="text-center">
-          <h6 className="text-danger text-center">
-            Current Deadline : {getHumanReadableDate(equipmentEndDate)}{' '}
-          </h6>
-        </Placeholder>
-        <div className="d-grid gap-2 mt-4 text-center px-4">
-          {fellowshipEquipmentRecord === null && (
-            <MenuButton
-              name="Fill Campaign Form"
-              onClick={() => navigate(`/campaigns/fellowship/equipment/form`)}
-            />
-          )}
+    <ApolloWrapper loading={loading} data={data}>
+      <div className="d-flex align-items-center justify-content-center ">
+        <Container>
+          <div className="text-center">
+            <HeadingPrimary>{`${church?.name} ${churchType}`}</HeadingPrimary>
+            <HeadingSecondary>Equipment Campaign</HeadingSecondary>
+          </div>
+          <Placeholder
+            as="h6"
+            loading={equipmentEndDateLoading}
+            className="text-center"
+          >
+            <h6 className="text-danger text-center">
+              Current Deadline : {getHumanReadableDate(equipmentEndDate)}{' '}
+            </h6>
+          </Placeholder>
+          <div className="d-grid gap-2 mt-4 text-center px-4">
+            {fellowshipEquipmentRecord === null && (
+              <MenuButton
+                name="Fill Campaign Form"
+                onClick={() => navigate(`/campaigns/fellowship/equipment/form`)}
+              />
+            )}
 
-          <MenuButton
-            name="View Trends"
-            onClick={() => navigate(`/campaigns/fellowship/equipment/trends`)}
-          />
-        </div>
-      </Container>
-    </div>
+            <MenuButton
+              name="View Trends"
+              onClick={() => navigate(`/campaigns/fellowship/equipment/trends`)}
+            />
+          </div>
+        </Container>
+      </div>
+    </ApolloWrapper>
   )
 }
 


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
I wrapped the apollo wrapper component over fellowship and constituency equipment campaign page to ensure the page is not loaded until data is present
## Description

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/Videos (if appropriate):

<!--Not optional. Please oblige so that your PR will be merged in due time!-->

https://user-images.githubusercontent.com/36607706/192168620-194d234f-2609-4f9e-be04-aeea3979daf0.mov


