### PR TITLE
fix: admin-339 fix cypher that checks if a fellowship has members to a…

### DIFF
--- a/api/src/resolvers/cypher/close-church-cypher.ts
+++ b/api/src/resolvers/cypher/close-church-cypher.ts
@@ -1,6 +1,6 @@
 export const checkFellowshipHasNoMembers = `
 MATCH (fellowship:Fellowship {id:$fellowshipId})
-MATCH (fellowship)<-[:BELONGS_TO]-(member:Member)
+OPTIONAL MATCH (fellowship)<-[:BELONGS_TO]-(member:Member)
 RETURN fellowship.name AS name, COUNT(member) AS memberCount
 `
 

--- a/api/src/resolvers/directory/directory-resolvers.ts
+++ b/api/src/resolvers/directory/directory-resolvers.ts
@@ -121,7 +121,7 @@ const directoryMutation = {
       })
     const fellowshipCheck = rearrangeCypherObject(fellowshipCheckResponse)
 
-    if (fellowshipCheck.memberCount) {
+    if (fellowshipCheck.memberCount > 0) {
       throw new Error(
         `${fellowshipCheck?.name} Fellowship has ${fellowshipCheck?.memberCount} members. Please transfer all members and try again.`
       )


### PR DESCRIPTION
…lways return data

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This PR alters the cypher that checks if a fellowship has members before closing it down to always return data. Added an optional match to ensure that there is always a returned value for member count.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
This has been tested on my localhost

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/Videos (if appropriate):

https://user-images.githubusercontent.com/36535410/192189114-e6903119-4c60-4274-895d-44de3598cbf5.mov



<!--Not optional. Please oblige so that your PR will be merged in due time!-->
