### PR TITLE
ADMIN-312 fix issue where constituency name is the same in confirm banking…

### DIFF
--- a/web-react-ts/src/pages/services/banking/anagkazo/ConfirmAnagkazoBanking.tsx
+++ b/web-react-ts/src/pages/services/banking/anagkazo/ConfirmAnagkazoBanking.tsx
@@ -34,7 +34,6 @@ const ConfirmAnagkazoBanking = () => {
   const { streamId, clickCard, constituencyId } = useContext(ChurchContext)
   const [isSubmitting, setSubmitting] = useState(false)
   const [defaultersData, setDefaultersData] = useState([])
-  const [selectedConstituency, setSelectedConstituency] = useState('')
   const { togglePopup, isOpen } = usePopup()
   const navigate = useNavigate()
 
@@ -43,18 +42,13 @@ const ConfirmAnagkazoBanking = () => {
     {
       variables: { id: streamId },
       fetchPolicy: 'cache-and-network',
-      onCompleted: (data) => {
-        setSelectedConstituency(
-          data?.streams[0]?.constitiuencyBankingDefaultersThisWeek[0].name
-        )
-      },
     }
   )
 
   const { data: constituencyServiceData } = useQuery(
     DISPLAY_AGGREGATE_SERVICE_RECORD,
     {
-      variables: { week: getWeekNumber(), constituencyId: constituencyId },
+      variables: { constituencyId: constituencyId, week: getWeekNumber() },
     }
   )
 
@@ -62,6 +56,10 @@ const ConfirmAnagkazoBanking = () => {
 
   const service =
     constituencyServiceData?.constituencies[0]?.aggregateServiceRecord
+
+  const selectedConstituencyName =
+    constituencyServiceData?.constituencies[0]?.name
+
   const bankingDefaultersList =
     data?.streams[0]?.constitiuencyBankingDefaultersThisWeek
 
@@ -125,7 +123,7 @@ const ConfirmAnagkazoBanking = () => {
               {isOpen && (
                 <Popup handleClose={togglePopup}>
                   <h3 className={`${theme} menu-subheading text-center`}>
-                    {selectedConstituency} Constituency
+                    {selectedConstituencyName} Constituency
                   </h3>
                   <h6 className="text-center">Confirm Offering?</h6>
                   <Table striped bordered hover variant="dark">
@@ -142,6 +140,11 @@ const ConfirmAnagkazoBanking = () => {
                       )}
                     </tbody>
                   </Table>
+                  <i className="text-danger">
+                    NB: You must only click this button if the amount the
+                    constituency is submitting is the same as what is displayed
+                    here
+                  </i>
                   <Button
                     variant="primary"
                     type="submit"

--- a/web-react-ts/src/pages/services/record-service/RecordServiceMutations.ts
+++ b/web-react-ts/src/pages/services/record-service/RecordServiceMutations.ts
@@ -126,9 +126,11 @@ export const DISPLAY_AGGREGATE_SERVICE_RECORD = gql`
   query aggregateServiceRecord($week: Int!, $constituencyId: ID!) {
     constituencies(where: { id: $constituencyId }) {
       id
+      name
       aggregateServiceRecord(week: $week) {
         id
         income
+        foreignCurrency
       }
     }
   }


### PR DESCRIPTION
… popup

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
fix issue where constituency name is the same in confirm banking popup.
this also add text to make alert users to confirm they cross check banking amount before clicking the button

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
yes on my local

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/Videos (if appropriate):

<!--Not optional. Please oblige so that your PR will be merged in due time!-->
<img width="395" alt="Screenshot 2022-09-29 at 8 47 56 AM" src="https://user-images.githubusercontent.com/36607706/192987284-564f029f-bc12-4990-bb30-caa5129d2350.png">

