### PR TITLE
fix: remove spaces in whatsapp defaulters message

### DIFF
--- a/web-react-ts/src/pages/services/defaulters/defaulters-utils.ts
+++ b/web-react-ts/src/pages/services/defaulters/defaulters-utils.ts
@@ -3,9 +3,11 @@ export const messageForAdminsOfDefaulters = (church: {
   formDefaultersThisWeekCount: number
   bankingDefaultersThisWeekCount: number
 }) => {
-  return encodeURI(`Hi ${church.admin?.firstName || ''}\n
-  Looks like you have\n\n
-  ${church.formDefaultersThisWeekCount} form defaulters this week and\n
-  ${church.bankingDefaultersThisWeekCount} Banking Defaulters.\n\n
-  Please follow up to make sure they fill the forms and bank their offerings.`)
+  return encodeURI(
+    `Hi ${church.admin?.firstName || ''}\nLooks like you have\n\n${
+      church.formDefaultersThisWeekCount
+    } form defaulters this week and\n${
+      church.bankingDefaultersThisWeekCount
+    } Banking Defaulters.\n\nPlease follow up to make sure they fill the forms and bank their offerings.`
+  )
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR removes unnecessary spaces in the defaulters whatsapp messages. 
<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
This has been tested on my localhost

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/Videos (if appropriate):
<img width="527" alt="image" src="https://user-images.githubusercontent.com/36535410/193360006-28a10e72-f095-4f38-a0e6-67ddbff353bc.png">

<!--Not optional. Please oblige so that your PR will be merged in due time!-->
