### PR TITLE
feat: add bankedBy field to constituency

### DIFF
--- a/api/src/schema/banking-anagkazo.graphql
+++ b/api/src/schema/banking-anagkazo.graphql
@@ -140,4 +140,32 @@ extend type Constituency {
       END AS banked
       """
     )
+
+  bankedBy: Member
+    @cypher(
+      statement: """
+      MATCH (this)
+      WITH date() as today, this
+      WITH  today.weekDay as theDay, today, this
+      WITH date(today) - duration({days: (theDay - 2)}) AS startDate, this
+      WITH [day in range(0, 5) | startDate + duration({days: day})] AS dates, this
+
+      MATCH (date:TimeGraph)
+      USING INDEX date:TimeGraph(date)
+      WHERE date.date IN dates
+      MATCH (date)<-[:SERVICE_HELD_ON]-(record:ServiceRecord)
+
+       WITH DISTINCT record, this
+        WHERE record.noServiceReason IS NULL
+        AND (record.bankingSlip IS NOT NULL OR record.transactionStatus ='success' OR record.tellerConfirmationTime IS NOT NULL)
+       MATCH (record)<-[:HAS_SERVICE]-(:ServiceLog)<-[:HAS_HISTORY]-(fellowships) WHERE fellowships:Fellowship OR fellowships:ClosedFellowship
+
+
+      WITH DISTINCT  this, record
+      MATCH (teller:Member)-[:CONFIRMED_BANKING_FOR]->(record:ServiceRecord)<-[:HAS_SERVICE]-(:ServiceLog)<-[:HAS_HISTORY]-(fellowships)<-[:HAS]-(:Bacenta)<-[:HAS]-(this)
+
+
+      RETURN DISTINCT teller
+      """
+    )
 }

--- a/web-react-ts/src/pages/services/defaulters/CouncilByConstituency.tsx
+++ b/web-react-ts/src/pages/services/defaulters/CouncilByConstituency.tsx
@@ -98,6 +98,12 @@ const CouncilByConstituency = () => {
                         </div>
                       </Card.Body>
                       <Card.Footer>
+                        {constituency?.bankedBy && (
+                          <div className="text-warning">
+                            Offering Received By :{' '}
+                            {`${constituency.bankedBy.firstName} ${constituency.bankedBy.lastName}`}
+                          </div>
+                        )}
                         <div className="mb-2">
                           Contact Admin: {constituency?.admin?.fullName}
                         </div>

--- a/web-react-ts/src/pages/services/defaulters/DefaultersQueries.ts
+++ b/web-react-ts/src/pages/services/defaulters/DefaultersQueries.ts
@@ -373,6 +373,11 @@ export const COUNCIL_BY_CONSTITUENCY = gql`
           phoneNumber
           whatsappNumber
         }
+        bankedBy {
+          id
+          firstName
+          lastName
+        }
         activeFellowshipCount
         formDefaultersThisWeekCount
         bankingDefaultersThisWeekCount

--- a/web-react-ts/src/pages/services/defaulters/defaulters-types.ts
+++ b/web-react-ts/src/pages/services/defaulters/defaulters-types.ts
@@ -1,5 +1,11 @@
 import { ApolloError } from '@apollo/client'
-import { Church, StreamOptions, Fellowship, ServiceRecord } from 'global-types'
+import {
+  Church,
+  StreamOptions,
+  Fellowship,
+  ServiceRecord,
+  Member,
+} from 'global-types'
 
 export interface FellowshipWithDefaulters extends Fellowship {
   __typename: 'Fellowship'
@@ -27,7 +33,7 @@ export interface HigherChurchWithDefaulters extends Church {
   bankedThisWeek: FellowshipWithDefaulters[]
   bankingDefaultersThisWeek: FellowshipWithDefaulters[]
   cancelledServicesThisWeek: FellowshipWithDefaulters[]
-
+  bankedBy: Member
   servicesThisWeekCount: number
   formDefaultersThisWeekCount: number
   bankedThisWeekCount: number


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds a field to constituency so that a stream admin in anagkazo can know who confirmed receipt of a constituencies offering

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
This has been tested on my localhost

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/Videos (if appropriate):
<img width="448" alt="image" src="https://user-images.githubusercontent.com/36535410/195616669-b1c2539a-ce40-4133-a391-7fee790217aa.png">


<!--Not optional. Please oblige so that your PR will be merged in due time!-->
