### PR TITLE
fix: fix check already filled cypher for services to also check for year

### DIFF
--- a/api/src/resolvers/services/service-cypher.ts
+++ b/api/src/resolvers/services/service-cypher.ts
@@ -3,7 +3,8 @@ MATCH (church {id: $churchId})
 WHERE church:Fellowship OR church:Bacenta OR church:Constituency OR church:Sonta OR church:Ministry
 
 
-OPTIONAL MATCH (church)-[:HAS_HISTORY]->(:ServiceLog)-[:HAS_SERVICE]->(record:ServiceRecord)-[:SERVICE_HELD_ON]->(date:TimeGraph) WHERE date(date.date).week = date().week
+OPTIONAL MATCH (church)-[:HAS_HISTORY]->(:ServiceLog)-[:HAS_SERVICE]->(record:ServiceRecord)-[:SERVICE_HELD_ON]->(date:TimeGraph)
+WHERE date(date.date).week = date().week AND date(date.date).year = date().year
         
 RETURN church.id AS id, church.name AS name, labels(church) AS labels, record AS alreadyFilled
 `


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This PR fixes a bug where the check for services this week doesn't check with years

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
This has been tested on my localhost and proven to be working

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/Videos (if appropriate):

<!--Not optiona
<img width="843" alt="Screenshot 2022-10-29 at 12 51 54 PM" src="https://user-images.githubusercontent.com/36535410/198832570-66484547-8001-418a-b53b-0b9d1f7d9353.png">
l. Please oblige so that your PR will be merged in due time!-->
