### PR TITLE
feat: add heading to Swollen Sunday church list page

### DIFF
--- a/web-react-ts/src/pages/campaigns/swollen-sunday/bacenta/SwollenSundayBacentaList.tsx
+++ b/web-react-ts/src/pages/campaigns/swollen-sunday/bacenta/SwollenSundayBacentaList.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@apollo/client'
 import ApolloWrapper from 'components/base-component/ApolloWrapper'
+import { HeadingPrimary } from 'components/HeadingPrimary/HeadingPrimary'
 import HeadingSecondary from 'components/HeadingSecondary'
 import { ChurchContext } from 'contexts/ChurchContext'
 import React, { useContext } from 'react'
@@ -20,6 +21,7 @@ const SwollenSundayBacentaList = () => {
   return (
     <ApolloWrapper loading={loading} error={error} data={data}>
       <div className="text-center">
+        <HeadingPrimary>Swollen Sunday Campaign</HeadingPrimary>
         <HeadingSecondary>
           {`${data?.constituencies[0]?.name} ${data?.constituencies[0]?.__typename}`}{' '}
           Bacentas

--- a/web-react-ts/src/pages/campaigns/swollen-sunday/constituency/SwollenSundayConstituencyList.tsx
+++ b/web-react-ts/src/pages/campaigns/swollen-sunday/constituency/SwollenSundayConstituencyList.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@apollo/client'
 import ApolloWrapper from 'components/base-component/ApolloWrapper'
+import { HeadingPrimary } from 'components/HeadingPrimary/HeadingPrimary'
 import HeadingSecondary from 'components/HeadingSecondary'
 import { ChurchContext } from 'contexts/ChurchContext'
 import React, { useContext } from 'react'
@@ -20,6 +21,7 @@ const SwollenSundayConstituencyList = () => {
   return (
     <ApolloWrapper loading={loading} error={error} data={data}>
       <div className="text-center">
+        <HeadingPrimary>Swollen Sunday Campaign</HeadingPrimary>
         <HeadingSecondary>
           {`${data?.councils[0]?.name} ${data?.councils[0]?.__typename}`}{' '}
           Constituencies

--- a/web-react-ts/src/pages/campaigns/swollen-sunday/council/SwollenSundayCouncilList.tsx
+++ b/web-react-ts/src/pages/campaigns/swollen-sunday/council/SwollenSundayCouncilList.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@apollo/client'
 import ApolloWrapper from 'components/base-component/ApolloWrapper'
+import { HeadingPrimary } from 'components/HeadingPrimary/HeadingPrimary'
 import HeadingSecondary from 'components/HeadingSecondary'
 import { ChurchContext } from 'contexts/ChurchContext'
 import React, { useContext } from 'react'
@@ -20,6 +21,7 @@ const SwollenSundayCouncilList = () => {
   return (
     <ApolloWrapper loading={loading} error={error} data={data}>
       <div className="text-center">
+        <HeadingPrimary>Swollen Sunday Campaign</HeadingPrimary>
         <HeadingSecondary>
           {`${data?.streams[0]?.name} ${data?.streams[0]?.__typename}`} Councils
         </HeadingSecondary>

--- a/web-react-ts/src/pages/campaigns/swollen-sunday/stream/SwollenSundayStreamList.tsx
+++ b/web-react-ts/src/pages/campaigns/swollen-sunday/stream/SwollenSundayStreamList.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@apollo/client'
 import ApolloWrapper from 'components/base-component/ApolloWrapper'
+import { HeadingPrimary } from 'components/HeadingPrimary/HeadingPrimary'
 import HeadingSecondary from 'components/HeadingSecondary'
 import { ChurchContext } from 'contexts/ChurchContext'
 import React, { useContext } from 'react'
@@ -20,6 +21,7 @@ const SwollenSundayStreamList = () => {
   return (
     <ApolloWrapper loading={loading} error={error} data={data}>
       <div className="text-center">
+        <HeadingPrimary>Swollen Sunday Campaign</HeadingPrimary>
         <HeadingSecondary>
           {`${data?.gatheringServices[0]?.name} ${data?.gatheringServices[0]?.__typename}`}{' '}
           Streams


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Added Swollen Campaign header to the swollen sunday church list page so that users can know which page they are on

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
I have tested this on my local machine
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/Videos (if appropriate):

<!--Not optional. Please oblige so that your PR will be merged in due time!-->

<img width="400" alt="Screenshot 2022-12-23 at 8 34 32 AM" src="https://user-images.githubusercontent.com/36607706/209302290-85546b22-1f9d-4632-828a-65e1c5a3b69f.png">

