### PR TITLE
admin-492-BUG/order-swollen-sunday-grap

### DIFF
--- a/api/src/schema/campaigns-swollen-sunday.graphql
+++ b/api/src/schema/campaigns-swollen-sunday.graphql
@@ -21,7 +21,7 @@ extend type Oversight {
 
       WITH collect(DISTINCT(date(swell.date).week)) as list, aggregate, this, target
       MATCH (aggregate) WHERE aggregate.week IN list
-      RETURN {attendance: toFloat(aggregate.attendance),target: target.target, week: aggregate.week}
+      RETURN {attendance: toFloat(aggregate.attendance),target: target.target, week: aggregate.week} ORDER BY aggregate.week DESC
       """
     )
 }
@@ -38,7 +38,7 @@ extend type GatheringService {
 
       WITH collect(DISTINCT(date(swell.date).week)) as list, aggregate, this, target
       MATCH (aggregate) WHERE aggregate.week IN list
-      RETURN {attendance: toFloat(aggregate.attendance),target: target.target, week: aggregate.week}
+      RETURN {attendance: toFloat(aggregate.attendance),target: target.target, week: aggregate.week} ORDER BY aggregate.week DESC
       """
     )
   swellTarget: Target
@@ -64,7 +64,7 @@ extend type Stream {
 
       WITH collect(DISTINCT(date(swell.date).week)) as list, aggregate, this, target
       MATCH (aggregate) WHERE aggregate.week IN list
-      RETURN {attendance: toFloat(aggregate.attendance),target: target.target, week: aggregate.week}
+      RETURN {attendance: toFloat(aggregate.attendance),target: target.target, week: aggregate.week} ORDER BY aggregate.week DESC
       """
     )
   swellTarget: Target
@@ -90,7 +90,7 @@ extend type Council {
 
       WITH collect(DISTINCT(date(swell.date).week)) as list, aggregate, this, target
       MATCH (aggregate) WHERE aggregate.week IN list
-      RETURN {attendance: toFloat(aggregate.attendance),target: target.target, week: aggregate.week}
+      RETURN {attendance: toFloat(aggregate.attendance),target: target.target, week: aggregate.week} ORDER BY aggregate.week DESC
       """
     )
   swellTarget: Target!
@@ -116,7 +116,7 @@ extend type Constituency {
 
       WITH collect(DISTINCT(date(swell.date).week)) as list, aggregate, this, target
       MATCH (aggregate) WHERE aggregate.week IN list
-      RETURN {attendance: toFloat(aggregate.attendance),target: target.target, week: aggregate.week}
+      RETURN {attendance: toFloat(aggregate.attendance),target: target.target, week: aggregate.week} ORDER BY aggregate.week DESC
       """
     )
   swellTarget: Target!
@@ -142,7 +142,7 @@ extend type Bacenta {
 
       WITH collect(DISTINCT(date(swell.date).week)) as list, aggregate, this, target
       MATCH (aggregate) WHERE aggregate.week IN list
-      RETURN {attendance: toFloat(aggregate.attendance),target: target.target, week: aggregate.week}
+      RETURN {attendance: toFloat(aggregate.attendance),target: target.target, week: aggregate.week} ORDER BY aggregate.week DESC
       """
     )
   swellTarget: Target!


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR fixes a bug where the swell statistics are not returned ordered by week number

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
This has been tested on my localhost

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/Videos (if appropriate):
https://www.loom.com/share/febe7b24a5c74c7b91f8759e6a7ac7f9

<!--Not optional. Please oblige so that your PR will be merged in due time!-->
