### PR TITLE
Update role permissions for directory CRUD operations to include adminCouncil

### DIFF
--- a/api/src/schema/directory-crud.graphql
+++ b/api/src/schema/directory-crud.graphql
@@ -556,6 +556,7 @@ extend type Mutation {
     @authentication(
       jwt: {
         OR: [
+          { roles_INCLUDES: "adminCouncil" }
           { roles_INCLUDES: "adminStream" }
           { roles_INCLUDES: "adminCampus" }
           { roles_INCLUDES: "arrivalsAdminCampus" }

--- a/web-react-ts/src/pages/directory/directoryRoutes.ts
+++ b/web-react-ts/src/pages/directory/directoryRoutes.ts
@@ -676,7 +676,7 @@ export const directory: LazyRouteTypes[] = [
   {
     path: '/bacenta/addbacenta',
     element: CreateBacenta,
-    roles: permitAdminArrivals('Stream'),
+    roles: permitAdminArrivals('Council'),
     placeholder: false,
   },
 

--- a/web-react-ts/src/pages/directory/display/AllBacentas.tsx
+++ b/web-react-ts/src/pages/directory/display/AllBacentas.tsx
@@ -58,7 +58,7 @@ const DisplayAllBacentas = () => {
               </Link>
             ) : null}
           </Col>
-          <RoleView roles={permitAdminArrivals('Stream')} directoryLock>
+          <RoleView roles={permitAdminArrivals('Council')} directoryLock>
             <Col className="col-auto">
               <Link
                 to="/bacenta/addbacenta"


### PR DESCRIPTION
Enhance role permissions by adding support for the adminCouncil role in directory CRUD operations and updating related routes and components accordingly.