### PR TITLE
Develop

### DIFF
--- a/api/src/index.js
+++ b/api/src/index.js
@@ -23,8 +23,29 @@ const startServer = async () => {
     neo4j.auth.basic(
       SECRETS.NEO4J_USER || 'neo4j',
       SECRETS.NEO4J_PASSWORD || 'letmein'
-    )
+    ),
+    {
+      encrypted: 'ENCRYPTION_ON',
+      trust: 'TRUST_ALL_CERTIFICATES',
+      connectionTimeout: 30000,
+    }
   )
+
+  // Add connection verification
+  try {
+    await driver.verifyConnectivity()
+    console.log('✅ Neo4j connection verified successfully')
+
+    // Test a simple query
+    const session = driver.session()
+    const result = await session.run('RETURN 1 as test')
+    console.log('✅ Test query successful:', result.records[0].get('test'))
+    await session.close()
+  } catch (error) {
+    console.error('❌ Neo4j connection failed:', error.message)
+    console.error('Full error:', error)
+    process.exit(1)
+  }
 
   const neoSchema = new Neo4jGraphQL({
     typeDefs,

--- a/api/src/schema/aggregates.graphql
+++ b/api/src/schema/aggregates.graphql
@@ -21,147 +21,147 @@ type AggregateBussingRecord {
 }
 
 extend type Bacenta {
-  aggregateServiceRecords(limit: Int! = 4): [AggregateServiceRecord!]!
+  aggregateServiceRecords(limit: Int! = 4, skip: Int = 0): [AggregateServiceRecord!]!
     @cypher(
       statement: """
       MATCH (this)-[:HAS_HISTORY]->(:ServiceLog)-[:HAS_SERVICE_AGGREGATE]->(aggregate:AggregateServiceRecord)
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
-      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC LIMIT $limit
+      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
-  aggregateBussingRecords(limit: Int! = 4): [AggregateBussingRecord!]!
+  aggregateBussingRecords(limit: Int! = 4, skip: Int = 0): [AggregateBussingRecord!]!
     @cypher(
       statement: """
       MATCH (this)-[:HAS_HISTORY]->(:ServiceLog)-[:HAS_BUSSING_AGGREGATE]->(aggregate:AggregateBussingRecord)
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
-      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC LIMIT $limit
+      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
 }
 
 extend type Governorship {
-  aggregateServiceRecords(limit: Int! = 4): [AggregateServiceRecord!]!
+  aggregateServiceRecords(limit: Int! = 4, skip: Int = 0): [AggregateServiceRecord!]!
     @cypher(
       statement: """
       MATCH (this)-[:HAS_HISTORY]->(:ServiceLog)-[:HAS_SERVICE_AGGREGATE]->(aggregate:AggregateServiceRecord)
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
-      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC LIMIT $limit
+      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
-  aggregateBussingRecords(limit: Int! = 4): [AggregateBussingRecord!]!
+  aggregateBussingRecords(limit: Int! = 4, skip: Int = 0): [AggregateBussingRecord!]!
     @cypher(
       statement: """
       MATCH (this)-[:HAS_HISTORY]->(:ServiceLog)-[:HAS_BUSSING_AGGREGATE]->(aggregate:AggregateBussingRecord)
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
-      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC LIMIT $limit
+      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
 }
 
 extend type Council {
-  aggregateServiceRecords(limit: Int! = 4): [AggregateServiceRecord!]!
+  aggregateServiceRecords(limit: Int! = 4, skip: Int = 0): [AggregateServiceRecord!]!
     @cypher(
       statement: """
       MATCH (this)-[:HAS_HISTORY]->(:ServiceLog)-[:HAS_SERVICE_AGGREGATE]->(aggregate:AggregateServiceRecord)
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
-      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC LIMIT $limit
+      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
-  aggregateBussingRecords(limit: Int! = 4): [AggregateBussingRecord!]!
+  aggregateBussingRecords(limit: Int! = 4, skip: Int = 0): [AggregateBussingRecord!]!
     @cypher(
       statement: """
       MATCH (this)-[:HAS_HISTORY]->(:ServiceLog)-[:HAS_BUSSING_AGGREGATE]->(aggregate:AggregateBussingRecord)
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
-      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC LIMIT $limit
+      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
 }
 
 extend type Stream {
-  aggregateServiceRecords(limit: Int! = 4): [AggregateServiceRecord!]!
+  aggregateServiceRecords(limit: Int! = 4, skip: Int = 0): [AggregateServiceRecord!]!
     @cypher(
       statement: """
       MATCH (this)-[:HAS_HISTORY]->(:ServiceLog)-[:HAS_SERVICE_AGGREGATE]->(aggregate:AggregateServiceRecord)
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
-      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC LIMIT $limit
+      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
-  aggregateBussingRecords(limit: Int! = 4): [AggregateBussingRecord!]!
+  aggregateBussingRecords(limit: Int! = 4, skip: Int = 0): [AggregateBussingRecord!]!
     @cypher(
       statement: """
       MATCH (this)-[:HAS_HISTORY]->(:ServiceLog)-[:HAS_BUSSING_AGGREGATE]->(aggregate:AggregateBussingRecord)
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
-      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC LIMIT $limit
+      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
 }
 
 extend type Campus {
-  aggregateServiceRecords(limit: Int! = 4): [AggregateServiceRecord!]!
+  aggregateServiceRecords(limit: Int! = 4, skip: Int = 0): [AggregateServiceRecord!]!
     @cypher(
       statement: """
       MATCH (this)-[:HAS_HISTORY]->(:ServiceLog)-[:HAS_SERVICE_AGGREGATE]->(aggregate:AggregateServiceRecord)
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
-      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC LIMIT $limit
+      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
-  aggregateBussingRecords(limit: Int! = 4): [AggregateBussingRecord!]!
+  aggregateBussingRecords(limit: Int! = 4, skip: Int = 0): [AggregateBussingRecord!]!
     @cypher(
       statement: """
       MATCH (this)-[:HAS_HISTORY]->(:ServiceLog)-[:HAS_BUSSING_AGGREGATE]->(aggregate:AggregateBussingRecord)
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
-      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC LIMIT $limit
+      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
 }
 
 extend type Oversight {
-  aggregateServiceRecords(limit: Int! = 4): [AggregateServiceRecord!]!
+  aggregateServiceRecords(limit: Int! = 4, skip: Int = 0): [AggregateServiceRecord!]!
     @cypher(
       statement: """
       MATCH (this)-[:HAS_HISTORY]->(:ServiceLog)-[:HAS_SERVICE_AGGREGATE]->(aggregate:AggregateServiceRecord)
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
-      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC LIMIT $limit
+      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
-  aggregateBussingRecords(limit: Int! = 4): [AggregateBussingRecord!]!
+  aggregateBussingRecords(limit: Int! = 4, skip: Int = 0): [AggregateBussingRecord!]!
     @cypher(
       statement: """
       MATCH (this)-[:HAS_HISTORY]->(:ServiceLog)-[:HAS_BUSSING_AGGREGATE]->(aggregate:AggregateBussingRecord)
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
-      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC LIMIT $limit
+      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
 }
 
 extend type Denomination {
-  aggregateServiceRecords(limit: Int! = 4): [AggregateServiceRecord!]!
+  aggregateServiceRecords(limit: Int! = 4, skip: Int = 0): [AggregateServiceRecord!]!
     @cypher(
       statement: """
       MATCH (this)-[:HAS_HISTORY]->(:ServiceLog)-[:HAS_SERVICE_AGGREGATE]->(aggregate:AggregateServiceRecord)
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
-      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC LIMIT $limit
+      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
-  aggregateBussingRecords(limit: Int! = 4): [AggregateBussingRecord!]!
+  aggregateBussingRecords(limit: Int! = 4, skip: Int = 0): [AggregateBussingRecord!]!
     @cypher(
       statement: """
       MATCH (this)-[:HAS_HISTORY]->(:ServiceLog)-[:HAS_BUSSING_AGGREGATE]->(aggregate:AggregateBussingRecord)
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
-      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC LIMIT $limit
+      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )

--- a/api/src/schema/arrivals.graphql
+++ b/api/src/schema/arrivals.graphql
@@ -1051,11 +1051,11 @@ extend type Bacenta {
       statement: "MATCH (arrivals:ArrivalsCodeOfTheDay) RETURN arrivals.code AS arrivalsCodeOfTheDay"
       columnName: "arrivalsCodeOfTheDay"
     )
-  bussing(limit: Int!): [BussingRecord!]!
+  bussing(limit: Int!, skip: Int = 0): [BussingRecord!]!
     @cypher(
       statement: """
       MATCH (this)-[:HAS_HISTORY]->(:ServiceLog)-[:HAS_BUSSING]->(bussing:BussingRecord)-[:BUSSED_ON]->(date:TimeGraph)
-      RETURN bussing ORDER BY date.date DESC LIMIT $limit
+      RETURN bussing ORDER BY date.date DESC SKIP $skip LIMIT $limit
       """
       columnName: "bussing"
     )

--- a/api/src/schema/services.graphql
+++ b/api/src/schema/services.graphql
@@ -1106,6 +1106,16 @@ extend type Mutation {
       """
       columnName: "bacenta"
     )
+  DeleteServiceRecord(serviceRecordId: ID!): String!
+    @authentication(jwt: { OR: [{ roles_INCLUDES: "fishers" }] })
+    @cypher(
+      statement: """
+      MATCH (this:ServiceRecord {id: $serviceRecordId})
+      DETACH DELETE this
+      RETURN  "Deleted Successfully" AS message
+      """
+      columnName: "message"
+    )
 }
 
 extend type Campus {

--- a/web-react-ts/src/pages/services/graphs/BacentaGraphs.tsx
+++ b/web-react-ts/src/pages/services/graphs/BacentaGraphs.tsx
@@ -44,7 +44,7 @@ export const BacentaGraphs = () => {
       setChurchData(getServiceGraphData(data?.bacentas[0], graphs))
       refetch({ id: bacentaId, limit, skip: 0 })
     }
-  }, [graphs, data?.bacentas, bacentaId, refetch])
+  }, [graphs, bacentaId, refetch])
 
   const handlePrevious = useCallback(() => {
     const newSkip = Math.max(0, skip - limit)
@@ -89,47 +89,6 @@ export const BacentaGraphs = () => {
           </Col>
         </Row>
 
-        {/* Navigation Controls */}
-        <Row className="mt-3 justify-content-center">
-          <Col xs="auto">
-            <div className="d-flex align-items-center gap-3">
-              <Button
-                variant="outline-secondary"
-                size="sm"
-                onClick={handlePrevious}
-                disabled={!canGoBack || loading || isNavigating}
-                className="d-flex align-items-center"
-              >
-                {isNavigating ? (
-                  <Spinner size="sm" className="me-1" />
-                ) : (
-                  <ChevronLeft size={16} className="me-1" />
-                )}
-                Previous
-              </Button>
-
-              <span className="text-muted small">
-                Records {skip + 1} - {skip + (churchData?.length || 0)}
-              </span>
-
-              <Button
-                variant="outline-secondary"
-                size="sm"
-                onClick={handleNext}
-                disabled={!canGoForward || loading || isNavigating}
-                className="d-flex align-items-center"
-              >
-                Next
-                {isNavigating ? (
-                  <Spinner size="sm" className="ms-1" />
-                ) : (
-                  <ChevronRight size={16} className="ms-1" />
-                )}
-              </Button>
-            </div>
-          </Col>
-        </Row>
-
         <Row className="mt-3">
           <Col>
             <StatDisplay
@@ -168,6 +127,51 @@ export const BacentaGraphs = () => {
             income={false}
           />
         )}
+
+        {/* Navigation Controls */}
+        <Row className="mt-3 justify-content-center">
+          <Col xs="auto">
+            <div className="d-flex align-items-center gap-3">
+              <Button
+                variant="outline-secondary"
+                size="sm"
+                onClick={handleNext}
+                disabled={!canGoForward || loading || isNavigating}
+                className="d-flex align-items-center"
+              >
+                {isNavigating ? (
+                  <Spinner size="sm" className="me-1" />
+                ) : (
+                  <ChevronLeft size={16} className="me-1" />
+                )}
+                Previous
+              </Button>
+
+              <span className="text-muted small">
+                {churchData && churchData.length > 0
+                  ? `Weeks ${Math.min(
+                      ...churchData.map((d) => d.week || 0)
+                    )} - ${Math.max(...churchData.map((d) => d.week || 0))}`
+                  : `Weeks ${skip + 1} - ${skip + (churchData?.length || 0)}`}
+              </span>
+
+              <Button
+                variant="outline-secondary"
+                size="sm"
+                onClick={handlePrevious}
+                disabled={!canGoBack || loading || isNavigating}
+                className="d-flex align-items-center"
+              >
+                {isNavigating ? (
+                  <Spinner size="sm" className="ms-1" />
+                ) : (
+                  <ChevronRight size={16} className="ms-1" />
+                )}
+                Next
+              </Button>
+            </div>
+          </Col>
+        </Row>
       </Container>
     </ApolloWrapper>
   )

--- a/web-react-ts/src/pages/services/graphs/CampusGraphs.tsx
+++ b/web-react-ts/src/pages/services/graphs/CampusGraphs.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react'
+import React, { useContext, useState, useCallback, useEffect } from 'react'
 
 import { ChurchContext } from '../../../contexts/ChurchContext'
 import { useQuery } from '@apollo/client'
@@ -12,24 +12,55 @@ import { CAMPUS_GRAPHS } from './GraphsQueries'
 import MembershipCard from './CompMembershipCard'
 import StatDisplay from './CompStatDisplay'
 import ApolloWrapper from 'components/base-component/ApolloWrapper'
-import { Col, Container, Row } from 'react-bootstrap'
+import { Col, Container, Row, Button, Spinner } from 'react-bootstrap'
 import GraphDropdown from './GraphDropdown'
 import { MemberContext } from 'contexts/MemberContext'
 import LeaderAvatar from 'components/LeaderAvatar/LeaderAvatar'
 import { isIncomeGraph } from 'global-utils'
+import { ChevronLeft, ChevronRight } from 'react-bootstrap-icons'
 
 const CampusReport = () => {
   const { campusId } = useContext(ChurchContext)
   const { currentUser } = useContext(MemberContext)
   const [graphs, setGraphs] = useState<GraphTypes>('bussingAggregate')
+  const [skip, setSkip] = useState(0)
+  const [isNavigating, setIsNavigating] = useState(false)
+  const limit = 4
   const [churchData, setChurchData] = useState<any[] | undefined>([])
-  const { data, loading, error } = useQuery(CAMPUS_GRAPHS, {
-    variables: { campusId },
+  const { data, loading, error, refetch } = useQuery(CAMPUS_GRAPHS, {
+    variables: { campusId, limit, skip },
     onCompleted: (data) => {
       if (!setChurchData) return
       setChurchData(getServiceGraphData(data?.campuses[0], graphs))
+      setIsNavigating(false)
     },
   })
+
+  // Reset skip when graph type changes
+  useEffect(() => {
+    setSkip(0)
+    if (data?.campuses[0]) {
+      setChurchData(getServiceGraphData(data?.campuses[0], graphs))
+      refetch({ campusId, limit, skip: 0 })
+    }
+  }, [graphs, campusId, refetch])
+
+  const handlePrevious = useCallback(() => {
+    const newSkip = Math.max(0, skip - limit)
+    setSkip(newSkip)
+    setIsNavigating(true)
+    refetch({ campusId, limit, skip: newSkip })
+  }, [skip, limit, campusId, refetch])
+
+  const handleNext = useCallback(() => {
+    const newSkip = skip + limit
+    setSkip(newSkip)
+    setIsNavigating(true)
+    refetch({ campusId, limit, skip: newSkip })
+  }, [skip, limit, campusId, refetch])
+
+  const canGoBack = skip > 0
+  const canGoForward = churchData && churchData.length === limit
 
   return (
     <ApolloWrapper loading={loading} error={error} data={data}>
@@ -96,6 +127,51 @@ const CampusReport = () => {
             income={false}
           />
         )}
+
+        {/* Navigation Controls */}
+        <Row className="mt-3 justify-content-center">
+          <Col xs="auto">
+            <div className="d-flex align-items-center gap-3">
+              <Button
+                variant="outline-secondary"
+                size="sm"
+                onClick={handleNext}
+                disabled={!canGoForward || loading || isNavigating}
+                className="d-flex align-items-center"
+              >
+                {isNavigating ? (
+                  <Spinner size="sm" className="me-1" />
+                ) : (
+                  <ChevronLeft size={16} className="me-1" />
+                )}
+                Previous
+              </Button>
+
+              <span className="text-muted small">
+                {churchData && churchData.length > 0
+                  ? `Weeks ${Math.min(
+                      ...churchData.map((d) => d.week || 0)
+                    )} - ${Math.max(...churchData.map((d) => d.week || 0))}`
+                  : `Weeks ${skip + 1} - ${skip + (churchData?.length || 0)}`}
+              </span>
+
+              <Button
+                variant="outline-secondary"
+                size="sm"
+                onClick={handlePrevious}
+                disabled={!canGoBack || loading || isNavigating}
+                className="d-flex align-items-center"
+              >
+                {isNavigating ? (
+                  <Spinner size="sm" className="ms-1" />
+                ) : (
+                  <ChevronRight size={16} className="ms-1" />
+                )}
+                Next
+              </Button>
+            </div>
+          </Col>
+        </Row>
       </Container>
     </ApolloWrapper>
   )

--- a/web-react-ts/src/pages/services/graphs/CouncilGraphs.tsx
+++ b/web-react-ts/src/pages/services/graphs/CouncilGraphs.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react'
+import React, { useContext, useState, useCallback, useEffect } from 'react'
 
 import { useQuery } from '@apollo/client'
 import {
@@ -11,26 +11,57 @@ import { COUNCIL_GRAPHS } from './GraphsQueries'
 import MembershipCard from './CompMembershipCard'
 import StatDisplay from './CompStatDisplay'
 import ApolloWrapper from 'components/base-component/ApolloWrapper'
-import { Col, Container, Row } from 'react-bootstrap'
+import { Col, Container, Row, Button, Spinner } from 'react-bootstrap'
 import { ChurchContext } from 'contexts/ChurchContext'
 import GraphDropdown from './GraphDropdown'
 import { MemberContext } from 'contexts/MemberContext'
 import LeaderAvatar from 'components/LeaderAvatar/LeaderAvatar'
 import { isIncomeGraph } from 'global-utils'
+import { ChevronLeft, ChevronRight } from 'react-bootstrap-icons'
 
 const CouncilReport = () => {
   const { councilId } = useContext(ChurchContext)
   const { currentUser } = useContext(MemberContext)
 
   const [graphs, setGraphs] = useState<GraphTypes>('bussingAggregate')
+  const [skip, setSkip] = useState(0)
+  const [isNavigating, setIsNavigating] = useState(false)
+  const limit = 4
   const [churchData, setChurchData] = useState<any[] | undefined>([])
-  const { data, loading, error } = useQuery(COUNCIL_GRAPHS, {
-    variables: { councilId },
+  const { data, loading, error, refetch } = useQuery(COUNCIL_GRAPHS, {
+    variables: { councilId, limit, skip },
     onCompleted: (data) => {
       if (!setChurchData) return
       setChurchData(getServiceGraphData(data?.councils[0], graphs))
+      setIsNavigating(false)
     },
   })
+
+  // Reset skip when graph type changes
+  useEffect(() => {
+    setSkip(0)
+    if (data?.councils[0]) {
+      setChurchData(getServiceGraphData(data?.councils[0], graphs))
+      refetch({ councilId, limit, skip: 0 })
+    }
+  }, [graphs, councilId, refetch])
+
+  const handlePrevious = useCallback(() => {
+    const newSkip = Math.max(0, skip - limit)
+    setSkip(newSkip)
+    setIsNavigating(true)
+    refetch({ councilId, limit, skip: newSkip })
+  }, [skip, limit, councilId, refetch])
+
+  const handleNext = useCallback(() => {
+    const newSkip = skip + limit
+    setSkip(newSkip)
+    setIsNavigating(true)
+    refetch({ councilId, limit, skip: newSkip })
+  }, [skip, limit, councilId, refetch])
+
+  const canGoBack = skip > 0
+  const canGoForward = churchData && churchData.length === limit
 
   return (
     <ApolloWrapper loading={loading} error={error} data={data}>
@@ -99,6 +130,51 @@ const CouncilReport = () => {
             income={false}
           />
         )}
+
+        {/* Navigation Controls */}
+        <Row className="mt-3 justify-content-center">
+          <Col xs="auto">
+            <div className="d-flex align-items-center gap-3">
+              <Button
+                variant="outline-secondary"
+                size="sm"
+                onClick={handleNext}
+                disabled={!canGoForward || loading || isNavigating}
+                className="d-flex align-items-center"
+              >
+                {isNavigating ? (
+                  <Spinner size="sm" className="me-1" />
+                ) : (
+                  <ChevronLeft size={16} className="me-1" />
+                )}
+                Previous
+              </Button>
+
+              <span className="text-muted small">
+                {churchData && churchData.length > 0
+                  ? `Weeks ${Math.min(
+                      ...churchData.map((d) => d.week || 0)
+                    )} - ${Math.max(...churchData.map((d) => d.week || 0))}`
+                  : `Weeks ${skip + 1} - ${skip + (churchData?.length || 0)}`}
+              </span>
+
+              <Button
+                variant="outline-secondary"
+                size="sm"
+                onClick={handlePrevious}
+                disabled={!canGoBack || loading || isNavigating}
+                className="d-flex align-items-center"
+              >
+                {isNavigating ? (
+                  <Spinner size="sm" className="ms-1" />
+                ) : (
+                  <ChevronRight size={16} className="ms-1" />
+                )}
+                Next
+              </Button>
+            </div>
+          </Col>
+        </Row>
       </Container>
     </ApolloWrapper>
   )

--- a/web-react-ts/src/pages/services/graphs/DenominationGraphs.tsx
+++ b/web-react-ts/src/pages/services/graphs/DenominationGraphs.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react'
+import React, { useContext, useState, useCallback, useEffect } from 'react'
 
 import { ChurchContext } from '../../../contexts/ChurchContext'
 import { useQuery } from '@apollo/client'
@@ -12,24 +12,55 @@ import { DENOMINATION_GRAPHS } from './GraphsQueries'
 import MembershipCard from './CompMembershipCard'
 import StatDisplay from './CompStatDisplay'
 import ApolloWrapper from 'components/base-component/ApolloWrapper'
-import { Col, Container, Row } from 'react-bootstrap'
+import { Col, Container, Row, Button, Spinner } from 'react-bootstrap'
 import GraphDropdown from './GraphDropdown'
 import { MemberContext } from 'contexts/MemberContext'
 import LeaderAvatar from 'components/LeaderAvatar/LeaderAvatar'
 import { isIncomeGraph } from 'global-utils'
+import { ChevronLeft, ChevronRight } from 'react-bootstrap-icons'
 
 const DenominationReport = () => {
   const { denominationId } = useContext(ChurchContext)
   const { currentUser } = useContext(MemberContext)
   const [graphs, setGraphs] = useState<GraphTypes>('serviceAggregateWithDollar')
+  const [skip, setSkip] = useState(0)
+  const [isNavigating, setIsNavigating] = useState(false)
+  const limit = 4
   const [churchData, setChurchData] = useState<any[] | undefined>([])
-  const { data, loading, error } = useQuery(DENOMINATION_GRAPHS, {
-    variables: { denominationId },
+  const { data, loading, error, refetch } = useQuery(DENOMINATION_GRAPHS, {
+    variables: { denominationId, limit, skip },
     onCompleted: (data) => {
       if (!setChurchData) return
       setChurchData(getServiceGraphData(data?.denominations[0], graphs))
+      setIsNavigating(false)
     },
   })
+
+  // Reset skip when graph type changes
+  useEffect(() => {
+    setSkip(0)
+    if (data?.denominations[0]) {
+      setChurchData(getServiceGraphData(data?.denominations[0], graphs))
+      refetch({ denominationId, limit, skip: 0 })
+    }
+  }, [graphs, denominationId, refetch])
+
+  const handlePrevious = useCallback(() => {
+    const newSkip = Math.max(0, skip - limit)
+    setSkip(newSkip)
+    setIsNavigating(true)
+    refetch({ denominationId, limit, skip: newSkip })
+  }, [skip, limit, denominationId, refetch])
+
+  const handleNext = useCallback(() => {
+    const newSkip = skip + limit
+    setSkip(newSkip)
+    setIsNavigating(true)
+    refetch({ denominationId, limit, skip: newSkip })
+  }, [skip, limit, denominationId, refetch])
+
+  const canGoBack = skip > 0
+  const canGoForward = churchData && churchData.length === limit
 
   return (
     <ApolloWrapper loading={loading} error={error} data={data}>
@@ -96,6 +127,51 @@ const DenominationReport = () => {
             income={false}
           />
         )}
+
+        {/* Navigation Controls */}
+        <Row className="mt-3 justify-content-center">
+          <Col xs="auto">
+            <div className="d-flex align-items-center gap-3">
+              <Button
+                variant="outline-secondary"
+                size="sm"
+                onClick={handleNext}
+                disabled={!canGoForward || loading || isNavigating}
+                className="d-flex align-items-center"
+              >
+                {isNavigating ? (
+                  <Spinner size="sm" className="me-1" />
+                ) : (
+                  <ChevronLeft size={16} className="me-1" />
+                )}
+                Previous
+              </Button>
+
+              <span className="text-muted small">
+                {churchData && churchData.length > 0
+                  ? `Weeks ${Math.min(
+                      ...churchData.map((d) => d.week || 0)
+                    )} - ${Math.max(...churchData.map((d) => d.week || 0))}`
+                  : `Weeks ${skip + 1} - ${skip + (churchData?.length || 0)}`}
+              </span>
+
+              <Button
+                variant="outline-secondary"
+                size="sm"
+                onClick={handlePrevious}
+                disabled={!canGoBack || loading || isNavigating}
+                className="d-flex align-items-center"
+              >
+                {isNavigating ? (
+                  <Spinner size="sm" className="ms-1" />
+                ) : (
+                  <ChevronRight size={16} className="ms-1" />
+                )}
+                Next
+              </Button>
+            </div>
+          </Col>
+        </Row>
       </Container>
     </ApolloWrapper>
   )

--- a/web-react-ts/src/pages/services/graphs/GovernorshipGraphs.tsx
+++ b/web-react-ts/src/pages/services/graphs/GovernorshipGraphs.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react'
+import React, { useContext, useState, useCallback, useEffect } from 'react'
 
 import { ChurchContext } from '../../../contexts/ChurchContext'
 import { useQuery } from '@apollo/client'
@@ -12,25 +12,56 @@ import { GOVERNORSHIP_GRAPHS } from './GraphsQueries'
 import MembershipCard from './CompMembershipCard'
 import StatDisplay from './CompStatDisplay'
 import ApolloWrapper from 'components/base-component/ApolloWrapper'
-import { Col, Container, Row } from 'react-bootstrap'
+import { Col, Container, Row, Button, Spinner } from 'react-bootstrap'
 import GraphDropdown from './GraphDropdown'
 import { MemberContext } from 'contexts/MemberContext'
 import LeaderAvatar from 'components/LeaderAvatar/LeaderAvatar'
 import { isIncomeGraph } from 'global-utils'
+import { ChevronLeft, ChevronRight } from 'react-bootstrap-icons'
 
 export const GovernorshipGraphs = () => {
   const { governorshipId } = useContext(ChurchContext)
   const { currentUser } = useContext(MemberContext)
 
   const [graphs, setGraphs] = useState<GraphTypes>('bussingAggregate')
+  const [skip, setSkip] = useState(0)
+  const [isNavigating, setIsNavigating] = useState(false)
+  const limit = 4
   const [churchData, setChurchData] = useState<any[] | undefined>([])
-  const { data, loading, error } = useQuery(GOVERNORSHIP_GRAPHS, {
-    variables: { id: governorshipId },
+  const { data, loading, error, refetch } = useQuery(GOVERNORSHIP_GRAPHS, {
+    variables: { id: governorshipId, limit, skip },
     onCompleted: (data) => {
       if (!setChurchData) return
       setChurchData(getServiceGraphData(data?.governorships[0], graphs))
+      setIsNavigating(false)
     },
   })
+
+  // Reset skip when graph type changes
+  useEffect(() => {
+    setSkip(0)
+    if (data?.governorships[0]) {
+      setChurchData(getServiceGraphData(data?.governorships[0], graphs))
+      refetch({ id: governorshipId, limit, skip: 0 })
+    }
+  }, [graphs, governorshipId, refetch])
+
+  const handlePrevious = useCallback(() => {
+    const newSkip = Math.max(0, skip - limit)
+    setSkip(newSkip)
+    setIsNavigating(true)
+    refetch({ id: governorshipId, limit, skip: newSkip })
+  }, [skip, limit, governorshipId, refetch])
+
+  const handleNext = useCallback(() => {
+    const newSkip = skip + limit
+    setSkip(newSkip)
+    setIsNavigating(true)
+    refetch({ id: governorshipId, limit, skip: newSkip })
+  }, [skip, limit, governorshipId, refetch])
+
+  const canGoBack = skip > 0
+  const canGoForward = churchData && churchData.length === limit
 
   return (
     <ApolloWrapper loading={loading} error={error} data={data}>
@@ -97,6 +128,51 @@ export const GovernorshipGraphs = () => {
             income={false}
           />
         )}
+
+        {/* Navigation Controls */}
+        <Row className="mt-3 justify-content-center">
+          <Col xs="auto">
+            <div className="d-flex align-items-center gap-3">
+              <Button
+                variant="outline-secondary"
+                size="sm"
+                onClick={handleNext}
+                disabled={!canGoForward || loading || isNavigating}
+                className="d-flex align-items-center"
+              >
+                {isNavigating ? (
+                  <Spinner size="sm" className="me-1" />
+                ) : (
+                  <ChevronLeft size={16} className="me-1" />
+                )}
+                Previous
+              </Button>
+
+              <span className="text-muted small">
+                {churchData && churchData.length > 0
+                  ? `Weeks ${Math.min(
+                      ...churchData.map((d) => d.week || 0)
+                    )} - ${Math.max(...churchData.map((d) => d.week || 0))}`
+                  : `Weeks ${skip + 1} - ${skip + (churchData?.length || 0)}`}
+              </span>
+
+              <Button
+                variant="outline-secondary"
+                size="sm"
+                onClick={handlePrevious}
+                disabled={!canGoBack || loading || isNavigating}
+                className="d-flex align-items-center"
+              >
+                {isNavigating ? (
+                  <Spinner size="sm" className="ms-1" />
+                ) : (
+                  <ChevronRight size={16} className="ms-1" />
+                )}
+                Next
+              </Button>
+            </div>
+          </Col>
+        </Row>
       </Container>
     </ApolloWrapper>
   )

--- a/web-react-ts/src/pages/services/graphs/GraphsQueries.ts
+++ b/web-react-ts/src/pages/services/graphs/GraphsQueries.ts
@@ -82,7 +82,7 @@ export const BACENTA_GRAPHS = gql`
 `
 
 export const GOVERNORSHIP_GRAPHS = gql`
-  query governorshipGraphs($id: ID!) {
+  query governorshipGraphs($id: ID!, $limit: Int = 4, $skip: Int = 0) {
     governorships(where: { id: $id }) {
       id
       name
@@ -94,14 +94,14 @@ export const GOVERNORSHIP_GRAPHS = gql`
         pictureUrl
         nameWithTitle
       }
-      aggregateServiceRecords(limit: 4) {
+      aggregateServiceRecords(limit: $limit, skip: $skip) {
         id
         attendance
         income
         numberOfServices
         week
       }
-      aggregateBussingRecords(limit: 4) {
+      aggregateBussingRecords(limit: $limit, skip: $skip) {
         id
         attendance
         week
@@ -109,7 +109,7 @@ export const GOVERNORSHIP_GRAPHS = gql`
         numberOfUrvans
         numberOfCars
       }
-      services(limit: 4) {
+      services(limit: $limit, skip: $skip) {
         id
         createdAt
         attendance
@@ -126,7 +126,7 @@ export const GOVERNORSHIP_GRAPHS = gql`
 `
 
 export const COUNCIL_GRAPHS = gql`
-  query councilGraphs($councilId: ID!) {
+  query councilGraphs($councilId: ID!, $limit: Int = 4, $skip: Int = 0) {
     councils(where: { id: $councilId }) {
       id
       name
@@ -138,14 +138,14 @@ export const COUNCIL_GRAPHS = gql`
         pictureUrl
         nameWithTitle
       }
-      aggregateServiceRecords(limit: 4) {
+      aggregateServiceRecords(limit: $limit, skip: $skip) {
         id
         attendance
         income
         numberOfServices
         week
       }
-      aggregateBussingRecords(limit: 4) {
+      aggregateBussingRecords(limit: $limit, skip: $skip) {
         id
         attendance
         week
@@ -153,7 +153,7 @@ export const COUNCIL_GRAPHS = gql`
         numberOfUrvans
         numberOfCars
       }
-      services(limit: 4) {
+      services(limit: $limit, skip: $skip) {
         id
         createdAt
         attendance
@@ -170,7 +170,7 @@ export const COUNCIL_GRAPHS = gql`
 `
 
 export const STREAM_GRAPHS = gql`
-  query streamGraphs($streamId: ID!) {
+  query streamGraphs($streamId: ID!, $limit: Int = 4, $skip: Int = 0) {
     streams(where: { id: $streamId }) {
       id
       name
@@ -182,14 +182,14 @@ export const STREAM_GRAPHS = gql`
         pictureUrl
         nameWithTitle
       }
-      aggregateServiceRecords(limit: 4) {
+      aggregateServiceRecords(limit: $limit, skip: $skip) {
         id
         attendance
         income
         numberOfServices
         week
       }
-      aggregateBussingRecords(limit: 4) {
+      aggregateBussingRecords(limit: $limit, skip: $skip) {
         id
         attendance
         week
@@ -197,7 +197,7 @@ export const STREAM_GRAPHS = gql`
         numberOfUrvans
         numberOfCars
       }
-      services(limit: 4) {
+      services(limit: $limit, skip: $skip) {
         id
         createdAt
         attendance
@@ -214,7 +214,7 @@ export const STREAM_GRAPHS = gql`
 `
 
 export const CAMPUS_GRAPHS = gql`
-  query campusGraphs($campusId: ID!) {
+  query campusGraphs($campusId: ID!, $limit: Int = 4, $skip: Int = 0) {
     campuses(where: { id: $campusId }) {
       id
       name
@@ -226,7 +226,7 @@ export const CAMPUS_GRAPHS = gql`
         pictureUrl
         nameWithTitle
       }
-      aggregateServiceRecords(limit: 4) {
+      aggregateServiceRecords(limit: $limit, skip: $skip) {
         id
         attendance
         income
@@ -234,7 +234,7 @@ export const CAMPUS_GRAPHS = gql`
         numberOfServices
         week
       }
-      aggregateBussingRecords(limit: 4) {
+      aggregateBussingRecords(limit: $limit, skip: $skip) {
         id
         attendance
         week
@@ -242,7 +242,7 @@ export const CAMPUS_GRAPHS = gql`
         numberOfUrvans
         numberOfCars
       }
-      services(limit: 4) {
+      services(limit: $limit, skip: $skip) {
         id
         createdAt
         attendance
@@ -259,7 +259,7 @@ export const CAMPUS_GRAPHS = gql`
 `
 
 export const OVERSIGHT_GRAPHS = gql`
-  query oversightGraphs($oversightId: ID!) {
+  query oversightGraphs($oversightId: ID!, $limit: Int = 4, $skip: Int = 0) {
     oversights(where: { id: $oversightId }) {
       id
       name
@@ -271,14 +271,14 @@ export const OVERSIGHT_GRAPHS = gql`
         pictureUrl
         nameWithTitle
       }
-      aggregateServiceRecords(limit: 4) {
+      aggregateServiceRecords(limit: $limit, skip: $skip) {
         id
         attendance
         income
         numberOfServices
         week
       }
-      aggregateBussingRecords(limit: 4) {
+      aggregateBussingRecords(limit: $limit, skip: $skip) {
         id
         attendance
         week
@@ -286,7 +286,7 @@ export const OVERSIGHT_GRAPHS = gql`
         numberOfUrvans
         numberOfCars
       }
-      services(limit: 4) {
+      services(limit: $limit, skip: $skip) {
         id
         createdAt
         attendance
@@ -303,7 +303,11 @@ export const OVERSIGHT_GRAPHS = gql`
 `
 
 export const DENOMINATION_GRAPHS = gql`
-  query denominationGraphs($denominationId: ID!) {
+  query denominationGraphs(
+    $denominationId: ID!
+    $limit: Int = 4
+    $skip: Int = 0
+  ) {
     denominations(where: { id: $denominationId }) {
       id
       name
@@ -315,7 +319,7 @@ export const DENOMINATION_GRAPHS = gql`
         pictureUrl
         nameWithTitle
       }
-      aggregateServiceRecords(limit: 4) {
+      aggregateServiceRecords(limit: $limit, skip: $skip) {
         id
         attendance
         income
@@ -323,7 +327,7 @@ export const DENOMINATION_GRAPHS = gql`
         numberOfServices
         week
       }
-      aggregateBussingRecords(limit: 4) {
+      aggregateBussingRecords(limit: $limit, skip: $skip) {
         id
         attendance
         week

--- a/web-react-ts/src/pages/services/graphs/GraphsQueries.ts
+++ b/web-react-ts/src/pages/services/graphs/GraphsQueries.ts
@@ -29,7 +29,7 @@ export const FELLOWSHIP_GRAPHS = gql`
 `
 
 export const BACENTA_GRAPHS = gql`
-  query bacentaGraphs($id: ID!) {
+  query bacentaGraphs($id: ID!, $limit: Int = 4, $skip: Int = 0) {
     bacentas(where: { id: $id }) {
       id
       name
@@ -41,14 +41,14 @@ export const BACENTA_GRAPHS = gql`
         pictureUrl
         nameWithTitle
       }
-      aggregateServiceRecords(limit: 4) {
+      aggregateServiceRecords(limit: $limit, skip: $skip) {
         id
         attendance
         income
         numberOfServices
         week
       }
-      aggregateBussingRecords(limit: 4) {
+      aggregateBussingRecords(limit: $limit, skip: $skip) {
         id
         attendance
         week
@@ -56,7 +56,7 @@ export const BACENTA_GRAPHS = gql`
         numberOfUrvans
         numberOfCars
       }
-      services(limit: 4) {
+      services(limit: $limit, skip: $skip) {
         id
         createdAt
         attendance
@@ -66,7 +66,7 @@ export const BACENTA_GRAPHS = gql`
           date
         }
       }
-      bussing(limit: 4) {
+      bussing(limit: $limit, skip: $skip) {
         id
         createdAt
         attendance

--- a/web-react-ts/src/pages/services/graphs/OversightGraphs.tsx
+++ b/web-react-ts/src/pages/services/graphs/OversightGraphs.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react'
+import React, { useContext, useState, useCallback, useEffect } from 'react'
 
 import { ChurchContext } from '../../../contexts/ChurchContext'
 import { useQuery } from '@apollo/client'
@@ -12,24 +12,55 @@ import { OVERSIGHT_GRAPHS } from './GraphsQueries'
 import MembershipCard from './CompMembershipCard'
 import StatDisplay from './CompStatDisplay'
 import ApolloWrapper from 'components/base-component/ApolloWrapper'
-import { Col, Container, Row } from 'react-bootstrap'
+import { Col, Container, Row, Button, Spinner } from 'react-bootstrap'
 import GraphDropdown from './GraphDropdown'
 import { MemberContext } from 'contexts/MemberContext'
 import LeaderAvatar from 'components/LeaderAvatar/LeaderAvatar'
 import { isIncomeGraph } from 'global-utils'
+import { ChevronLeft, ChevronRight } from 'react-bootstrap-icons'
 
 const OversightReport = () => {
   const { oversightId } = useContext(ChurchContext)
   const { currentUser } = useContext(MemberContext)
   const [graphs, setGraphs] = useState<GraphTypes>('serviceAggregateWithDollar')
+  const [skip, setSkip] = useState(0)
+  const [isNavigating, setIsNavigating] = useState(false)
+  const limit = 4
   const [churchData, setChurchData] = useState<any[] | undefined>([])
-  const { data, loading, error } = useQuery(OVERSIGHT_GRAPHS, {
-    variables: { oversightId },
+  const { data, loading, error, refetch } = useQuery(OVERSIGHT_GRAPHS, {
+    variables: { oversightId, limit, skip },
     onCompleted: (data) => {
       if (!setChurchData) return
       setChurchData(getServiceGraphData(data?.oversights[0], graphs))
+      setIsNavigating(false)
     },
   })
+
+  // Reset skip when graph type changes
+  useEffect(() => {
+    setSkip(0)
+    if (data?.oversights[0]) {
+      setChurchData(getServiceGraphData(data?.oversights[0], graphs))
+      refetch({ oversightId, limit, skip: 0 })
+    }
+  }, [graphs, oversightId, refetch])
+
+  const handlePrevious = useCallback(() => {
+    const newSkip = Math.max(0, skip - limit)
+    setSkip(newSkip)
+    setIsNavigating(true)
+    refetch({ oversightId, limit, skip: newSkip })
+  }, [skip, limit, oversightId, refetch])
+
+  const handleNext = useCallback(() => {
+    const newSkip = skip + limit
+    setSkip(newSkip)
+    setIsNavigating(true)
+    refetch({ oversightId, limit, skip: newSkip })
+  }, [skip, limit, oversightId, refetch])
+
+  const canGoBack = skip > 0
+  const canGoForward = churchData && churchData.length === limit
 
   return (
     <ApolloWrapper loading={loading} error={error} data={data}>
@@ -96,6 +127,51 @@ const OversightReport = () => {
             income={false}
           />
         )}
+
+        {/* Navigation Controls */}
+        <Row className="mt-3 justify-content-center">
+          <Col xs="auto">
+            <div className="d-flex align-items-center gap-3">
+              <Button
+                variant="outline-secondary"
+                size="sm"
+                onClick={handleNext}
+                disabled={!canGoForward || loading || isNavigating}
+                className="d-flex align-items-center"
+              >
+                {isNavigating ? (
+                  <Spinner size="sm" className="me-1" />
+                ) : (
+                  <ChevronLeft size={16} className="me-1" />
+                )}
+                Previous
+              </Button>
+
+              <span className="text-muted small">
+                {churchData && churchData.length > 0
+                  ? `Weeks ${Math.min(
+                      ...churchData.map((d) => d.week || 0)
+                    )} - ${Math.max(...churchData.map((d) => d.week || 0))}`
+                  : `Weeks ${skip + 1} - ${skip + (churchData?.length || 0)}`}
+              </span>
+
+              <Button
+                variant="outline-secondary"
+                size="sm"
+                onClick={handlePrevious}
+                disabled={!canGoBack || loading || isNavigating}
+                className="d-flex align-items-center"
+              >
+                {isNavigating ? (
+                  <Spinner size="sm" className="ms-1" />
+                ) : (
+                  <ChevronRight size={16} className="ms-1" />
+                )}
+                Next
+              </Button>
+            </div>
+          </Col>
+        </Row>
       </Container>
     </ApolloWrapper>
   )

--- a/web-react-ts/src/pages/services/graphs/StreamGraphs.tsx
+++ b/web-react-ts/src/pages/services/graphs/StreamGraphs.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react'
+import React, { useContext, useState, useCallback, useEffect } from 'react'
 
 import { ChurchContext } from '../../../contexts/ChurchContext'
 import { useQuery } from '@apollo/client'
@@ -12,25 +12,56 @@ import { STREAM_GRAPHS } from './GraphsQueries'
 import MembershipCard from './CompMembershipCard'
 import StatDisplay from './CompStatDisplay'
 import ApolloWrapper from 'components/base-component/ApolloWrapper'
-import { Col, Container, Row } from 'react-bootstrap'
+import { Col, Container, Row, Button, Spinner } from 'react-bootstrap'
 import GraphDropdown from './GraphDropdown'
 import { MemberContext } from 'contexts/MemberContext'
 import LeaderAvatar from 'components/LeaderAvatar/LeaderAvatar'
 import { isIncomeGraph } from 'global-utils'
+import { ChevronLeft, ChevronRight } from 'react-bootstrap-icons'
 
 const StreamReport = () => {
   const { currentUser } = useContext(MemberContext)
 
   const { streamId } = useContext(ChurchContext)
   const [graphs, setGraphs] = useState<GraphTypes>('services')
+  const [skip, setSkip] = useState(0)
+  const [isNavigating, setIsNavigating] = useState(false)
+  const limit = 4
   const [churchData, setChurchData] = useState<any[] | undefined>([])
-  const { data, loading, error } = useQuery(STREAM_GRAPHS, {
-    variables: { streamId: streamId },
+  const { data, loading, error, refetch } = useQuery(STREAM_GRAPHS, {
+    variables: { streamId: streamId, limit, skip },
     onCompleted: (data) => {
       if (!setChurchData) return
       setChurchData(getServiceGraphData(data?.streams[0], graphs))
+      setIsNavigating(false)
     },
   })
+
+  // Reset skip when graph type changes
+  useEffect(() => {
+    setSkip(0)
+    if (data?.streams[0]) {
+      setChurchData(getServiceGraphData(data?.streams[0], graphs))
+      refetch({ streamId, limit, skip: 0 })
+    }
+  }, [graphs, streamId, refetch])
+
+  const handlePrevious = useCallback(() => {
+    const newSkip = Math.max(0, skip - limit)
+    setSkip(newSkip)
+    setIsNavigating(true)
+    refetch({ streamId, limit, skip: newSkip })
+  }, [skip, limit, streamId, refetch])
+
+  const handleNext = useCallback(() => {
+    const newSkip = skip + limit
+    setSkip(newSkip)
+    setIsNavigating(true)
+    refetch({ streamId, limit, skip: newSkip })
+  }, [skip, limit, streamId, refetch])
+
+  const canGoBack = skip > 0
+  const canGoForward = churchData && churchData.length === limit
 
   return (
     <ApolloWrapper loading={loading} error={error} data={data}>
@@ -97,6 +128,51 @@ const StreamReport = () => {
             income={false}
           />
         )}
+
+        {/* Navigation Controls */}
+        <Row className="mt-3 justify-content-center">
+          <Col xs="auto">
+            <div className="d-flex align-items-center gap-3">
+              <Button
+                variant="outline-secondary"
+                size="sm"
+                onClick={handleNext}
+                disabled={!canGoForward || loading || isNavigating}
+                className="d-flex align-items-center"
+              >
+                {isNavigating ? (
+                  <Spinner size="sm" className="me-1" />
+                ) : (
+                  <ChevronLeft size={16} className="me-1" />
+                )}
+                Previous
+              </Button>
+
+              <span className="text-muted small">
+                {churchData && churchData.length > 0
+                  ? `Weeks ${Math.min(
+                      ...churchData.map((d) => d.week || 0)
+                    )} - ${Math.max(...churchData.map((d) => d.week || 0))}`
+                  : `Weeks ${skip + 1} - ${skip + (churchData?.length || 0)}`}
+              </span>
+
+              <Button
+                variant="outline-secondary"
+                size="sm"
+                onClick={handlePrevious}
+                disabled={!canGoBack || loading || isNavigating}
+                className="d-flex align-items-center"
+              >
+                {isNavigating ? (
+                  <Spinner size="sm" className="ms-1" />
+                ) : (
+                  <ChevronRight size={16} className="ms-1" />
+                )}
+                Next
+              </Button>
+            </div>
+          </Col>
+        </Row>
       </Container>
     </ApolloWrapper>
   )

--- a/web-react-ts/src/pages/services/record-service/RecordServiceMutations.ts
+++ b/web-react-ts/src/pages/services/record-service/RecordServiceMutations.ts
@@ -824,3 +824,9 @@ export const DISPLAY_CAMPUS_SERVICE = gql`
     }
   }
 `
+
+export const DELETE_SERVICE_RECORD = gql`
+  mutation deleteServiceRecord($serviceRecordId: ID!) {
+    DeleteServiceRecord(serviceRecordId: $serviceRecordId)
+  }
+`

--- a/web-react-ts/src/pages/services/record-service/ServiceDetails.tsx
+++ b/web-react-ts/src/pages/services/record-service/ServiceDetails.tsx
@@ -53,7 +53,6 @@ const ServiceDetails = ({ service, church, loading }: ServiceDetailsProps) => {
 
     setDeleting(true)
     try {
-      // TODO: Add delete mutation here
       await DeleteServiceRecord({
         variables: {
           serviceRecordId: service?.id,
@@ -311,7 +310,7 @@ const ServiceDetails = ({ service, church, loading }: ServiceDetailsProps) => {
                   >
                     View Last 4 Weeks
                   </Button>
-                  <RoleView roles={permitAdmin('Stream')}>
+                  <RoleView roles={['fishers']}>
                     <Button
                       variant="danger"
                       disabled={deleting}


### PR DESCRIPTION
This pull request introduces several improvements to both backend and frontend code, mainly focused on enhancing data pagination for aggregate records and bussing records, adding mutation capabilities, and improving the user experience for navigating weekly data in church graphs. The most significant changes are grouped below by theme.

**Backend: GraphQL Schema & API Improvements**
* Added `skip` parameter to aggregate and bussing record queries on all major church types (`Bacenta`, `Governorship`, `Council`, `Stream`, `Campus`, `Oversight`, `Denomination`) to support paginated fetching of records. The corresponding Cypher queries were updated to use `SKIP $skip LIMIT $limit`. [[1]](diffhunk://#diff-cbc7ad70e8bd849bdf45aaecdc91defb80f0d12ed563ee16cb476860349ac303L24-R164) [[2]](diffhunk://#diff-f0fb9b5fc7e1ccfa2069dcab526ff1abc28e108a8391ba9d257ea26b947da941L1054-R1058)
* Introduced a new mutation `DeleteServiceRecord` in `api/src/schema/services.graphql` to allow authorized users to delete a service record by ID.
* Improved Neo4j connection handling in `api/src/index.js` by adding encryption, certificate trust settings, connection timeout, and runtime connectivity verification with error handling and a test query.

**Frontend: Paginated Graph Navigation**
* Refactored the graph pages for `Bacenta`, `Campus`, and `Council` (files: `BacentaGraphs.tsx`, `CampusGraphs.tsx`, `CouncilGraphs.tsx`) to implement paginated navigation of weekly data using the new `skip` and `limit` parameters, and added navigation controls (Previous/Next buttons) with loading indicators and week range display. [[1]](diffhunk://#diff-fa61175020913e05394a27d7c56df3d15ebb288c45b40bb5d1f841b4d60213d8L15-R65) [[2]](diffhunk://#diff-fa61175020913e05394a27d7c56df3d15ebb288c45b40bb5d1f841b4d60213d8R130-R174) [[3]](diffhunk://#diff-5287f11a60bfcf6d5258fc57a3dc8269d83b570e7254ff06e3e91a2d1aaa00afL15-R64) [[4]](diffhunk://#diff-5287f11a60bfcf6d5258fc57a3dc8269d83b570e7254ff06e3e91a2d1aaa00afR130-R174) [[5]](diffhunk://#diff-c281f6f2cf7c34c1349e80073a57ea8fd5e58b25a6f37e587fe3b96a3cbee8fdL14-R65)
* Improved UX by resetting pagination (`skip`) when the graph type changes and ensuring the displayed data and controls update accordingly. [[1]](diffhunk://#diff-fa61175020913e05394a27d7c56df3d15ebb288c45b40bb5d1f841b4d60213d8L15-R65) [[2]](diffhunk://#diff-5287f11a60bfcf6d5258fc57a3dc8269d83b570e7254ff06e3e91a2d1aaa00afL15-R64) [[3]](diffhunk://#diff-c281f6f2cf7c34c1349e80073a57ea8fd5e58b25a6f37e587fe3b96a3cbee8fdL14-R65)

These changes collectively improve the scalability of data queries, provide better mutation capabilities for admins, and make it easier for users to browse historical weekly data in church graphs.