### PR TITLE
fix(graphs): correct week sorting to prevent mixed years in church gr…

### DIFF
--- a/api/src/schema/aggregates.graphql
+++ b/api/src/schema/aggregates.graphql
@@ -58,7 +58,7 @@ extend type Bacenta {
         dollarIncome: dollarIncome,
         numberOfServices: numberOfServices
       } AS aggregate
-      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC SKIP $skip LIMIT $limit
+      RETURN aggregate ORDER BY (aggregate.year * 100 + aggregate.week) DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
@@ -89,7 +89,7 @@ extend type Bacenta {
         numberOfCars: numberOfCars,
         bussingTopUp: bussingTopUp
       } AS aggregate
-      RETURN aggregate ORDER BY aggregate.year DESC, aggregate.week DESC SKIP $skip LIMIT $limit
+      RETURN aggregate ORDER BY (aggregate.year * 100 + aggregate.week) DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
@@ -106,7 +106,7 @@ extend type Governorship {
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
       WITH aggregate ORDER BY coalesce(aggregate.recomputedAt, datetime({epochSeconds: 0})) DESC
       WITH aggregate.week AS w, aggregate.year AS y, head(collect(aggregate)) AS aggregate
-      RETURN aggregate ORDER BY y DESC, w DESC SKIP $skip LIMIT $limit
+      RETURN aggregate ORDER BY (y * 100 + w) DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
@@ -120,7 +120,7 @@ extend type Governorship {
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
       WITH aggregate ORDER BY coalesce(aggregate.recomputedAt, datetime({epochSeconds: 0})) DESC
       WITH aggregate.week AS w, aggregate.year AS y, head(collect(aggregate)) AS aggregate
-      RETURN aggregate ORDER BY y DESC, w DESC SKIP $skip LIMIT $limit
+      RETURN aggregate ORDER BY (y * 100 + w) DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
@@ -137,7 +137,7 @@ extend type Council {
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
       WITH aggregate ORDER BY coalesce(aggregate.recomputedAt, datetime({epochSeconds: 0})) DESC
       WITH aggregate.week AS w, aggregate.year AS y, head(collect(aggregate)) AS aggregate
-      RETURN aggregate ORDER BY y DESC, w DESC SKIP $skip LIMIT $limit
+      RETURN aggregate ORDER BY (y * 100 + w) DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
@@ -151,7 +151,7 @@ extend type Council {
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
       WITH aggregate ORDER BY coalesce(aggregate.recomputedAt, datetime({epochSeconds: 0})) DESC
       WITH aggregate.week AS w, aggregate.year AS y, head(collect(aggregate)) AS aggregate
-      RETURN aggregate ORDER BY y DESC, w DESC SKIP $skip LIMIT $limit
+      RETURN aggregate ORDER BY (y * 100 + w) DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
@@ -168,7 +168,7 @@ extend type Stream {
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
       WITH aggregate ORDER BY coalesce(aggregate.recomputedAt, datetime({epochSeconds: 0})) DESC
       WITH aggregate.week AS w, aggregate.year AS y, head(collect(aggregate)) AS aggregate
-      RETURN aggregate ORDER BY y DESC, w DESC SKIP $skip LIMIT $limit
+      RETURN aggregate ORDER BY (y * 100 + w) DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
@@ -182,7 +182,7 @@ extend type Stream {
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
       WITH aggregate ORDER BY coalesce(aggregate.recomputedAt, datetime({epochSeconds: 0})) DESC
       WITH aggregate.week AS w, aggregate.year AS y, head(collect(aggregate)) AS aggregate
-      RETURN aggregate ORDER BY y DESC, w DESC SKIP $skip LIMIT $limit
+      RETURN aggregate ORDER BY (y * 100 + w) DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
@@ -199,7 +199,7 @@ extend type Campus {
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
       WITH aggregate ORDER BY coalesce(aggregate.recomputedAt, datetime({epochSeconds: 0})) DESC
       WITH aggregate.week AS w, aggregate.year AS y, head(collect(aggregate)) AS aggregate
-      RETURN aggregate ORDER BY y DESC, w DESC SKIP $skip LIMIT $limit
+      RETURN aggregate ORDER BY (y * 100 + w) DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
@@ -213,7 +213,7 @@ extend type Campus {
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
       WITH aggregate ORDER BY coalesce(aggregate.recomputedAt, datetime({epochSeconds: 0})) DESC
       WITH aggregate.week AS w, aggregate.year AS y, head(collect(aggregate)) AS aggregate
-      RETURN aggregate ORDER BY y DESC, w DESC SKIP $skip LIMIT $limit
+      RETURN aggregate ORDER BY (y * 100 + w) DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
@@ -230,7 +230,7 @@ extend type Oversight {
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
       WITH aggregate ORDER BY coalesce(aggregate.recomputedAt, datetime({epochSeconds: 0})) DESC
       WITH aggregate.week AS w, aggregate.year AS y, head(collect(aggregate)) AS aggregate
-      RETURN aggregate ORDER BY y DESC, w DESC SKIP $skip LIMIT $limit
+      RETURN aggregate ORDER BY (y * 100 + w) DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
@@ -244,7 +244,7 @@ extend type Oversight {
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
       WITH aggregate ORDER BY coalesce(aggregate.recomputedAt, datetime({epochSeconds: 0})) DESC
       WITH aggregate.week AS w, aggregate.year AS y, head(collect(aggregate)) AS aggregate
-      RETURN aggregate ORDER BY y DESC, w DESC SKIP $skip LIMIT $limit
+      RETURN aggregate ORDER BY (y * 100 + w) DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
@@ -261,7 +261,7 @@ extend type Denomination {
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
       WITH aggregate ORDER BY coalesce(aggregate.recomputedAt, datetime({epochSeconds: 0})) DESC
       WITH aggregate.week AS w, aggregate.year AS y, head(collect(aggregate)) AS aggregate
-      RETURN aggregate ORDER BY y DESC, w DESC SKIP $skip LIMIT $limit
+      RETURN aggregate ORDER BY (y * 100 + w) DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )
@@ -275,7 +275,7 @@ extend type Denomination {
       WHERE aggregate.year = date().year OR aggregate.year = date().year -1
       WITH aggregate ORDER BY coalesce(aggregate.recomputedAt, datetime({epochSeconds: 0})) DESC
       WITH aggregate.week AS w, aggregate.year AS y, head(collect(aggregate)) AS aggregate
-      RETURN aggregate ORDER BY y DESC, w DESC SKIP $skip LIMIT $limit
+      RETURN aggregate ORDER BY (y * 100 + w) DESC SKIP $skip LIMIT $limit
       """
       columnName: "aggregate"
     )


### PR DESCRIPTION
This pull request updates the way aggregate records are ordered in the `api/src/schema/aggregates.graphql` file. Instead of ordering by year and week as separate fields, the code now combines them into a single sortable value (`year * 100 + week`). This ensures more accurate and consistent descending ordering, especially when paginating results. Closes issue #511 

**Ordering improvements for aggregate queries:**

* Changed the `ORDER BY` clause for all aggregate record queries (service, bussing, rehearsal, and stage attendance) across all entity types (such as `Bacenta`, `Governorship`, `Council`, `Stream`, `Campus`, `Oversight`, `Denomination`, `Hub`, `HubCouncil`, `Ministry`, and `CreativeArts`) to use `(aggregate.year * 100 + aggregate.week)` instead of separate ordering by `year` and `week`. This provides a more reliable way to sort records in descending chronological order. [[1]](diffhunk://#diff-cbc7ad70e8bd849bdf45aaecdc91defb80f0d12ed563ee16cb476860349ac303L32-R32) [[2]](diffhunk://#diff-cbc7ad70e8bd849bdf45aaecdc91defb80f0d12ed563ee16cb476860349ac303L44-R44) [[3]](diffhunk://#diff-cbc7ad70e8bd849bdf45aaecdc91defb80f0d12ed563ee16cb476860349ac303L59-R59) [[4]](diffhunk://#diff-cbc7ad70e8bd849bdf45aaecdc91defb80f0d12ed563ee16cb476860349ac303L71-R71) [[5]](diffhunk://#diff-cbc7ad70e8bd849bdf45aaecdc91defb80f0d12ed563ee16cb476860349ac303L86-R86) [[6]](diffhunk://#diff-cbc7ad70e8bd849bdf45aaecdc91defb80f0d12ed563ee16cb476860349ac303L98-R98) [[7]](diffhunk://#diff-cbc7ad70e8bd849bdf45aaecdc91defb80f0d12ed563ee16cb476860349ac303L113-R113) [[8]](diffhunk://#diff-cbc7ad70e8bd849bdf45aaecdc91defb80f0d12ed563ee16cb476860349ac303L125-R125) [[9]](diffhunk://#diff-cbc7ad70e8bd849bdf45aaecdc91defb80f0d12ed563ee16cb476860349ac303L140-R140) [[10]](diffhunk://#diff-cbc7ad70e8bd849bdf45aaecdc91defb80f0d12ed563ee16cb476860349ac303L152-R152) [[11]](diffhunk://#diff-cbc7ad70e8bd849bdf45aaecdc91defb80f0d12ed563ee16cb476860349ac303L167-R167) [[12]](diffhunk://#diff-cbc7ad70e8bd849bdf45aaecdc91defb80f0d12ed563ee16cb476860349ac303L179-R179) [[13]](diffhunk://#diff-cbc7ad70e8bd849bdf45aaecdc91defb80f0d12ed563ee16cb476860349ac303L194-R194) [[14]](diffhunk://#diff-cbc7ad70e8bd849bdf45aaecdc91defb80f0d12ed563ee16cb476860349ac303L206-R206) [[15]](diffhunk://#diff-cbc7ad70e8bd849bdf45aaecdc91defb80f0d12ed563ee16cb476860349ac303L236-R236) [[16]](diffhunk://#diff-cbc7ad70e8bd849bdf45aaecdc91defb80f0d12ed563ee16cb476860349ac303L248-R248) [[17]](diffhunk://#diff-cbc7ad70e8bd849bdf45aaecdc91defb80f0d12ed563ee16cb476860349ac303L257-R257) [[18]](diffhunk://#diff-cbc7ad70e8bd849bdf45aaecdc91defb80f0d12ed563ee16cb476860349ac303L269-R269) [[19]](diffhunk://#diff-cbc7ad70e8bd849bdf45aaecdc91defb80f0d12ed563ee16cb476860349ac303L278-R278) [[20]](diffhunk://#diff-cbc7ad70e8bd849bdf45aaecdc91defb80f0d12ed563ee16cb476860349ac303L290-R290) [[21]](diffhunk://#diff-cbc7ad70e8bd849bdf45aaecdc91defb80f0d12ed563ee16cb476860349ac303L299-R299) [[22]](diffhunk://#diff-cbc7ad70e8bd849bdf45aaecdc91defb80f0d12ed563ee16cb476860349ac303L310-R310)