### PR TITLE
Add year suffix to week labels and tooltips for clarity

### DIFF
--- a/web-react-ts/src/components/ChurchGraph/ChurchGraph.tsx
+++ b/web-react-ts/src/components/ChurchGraph/ChurchGraph.tsx
@@ -171,7 +171,7 @@ const ChartTooltip = ({ active, payload, label }: ChartTooltipProps) => {
   return (
     <div className="min-w-44 rounded-xl border border-border bg-card px-3 py-2 shadow-lg">
       <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-        {label ? `Week ${label}` : ''}
+        {label || ''}
       </p>
       <div className="mt-2 space-y-1.5">
         {payload.map((entry) => (
@@ -333,7 +333,7 @@ const ChurchGraph = (props: ChurchGraphProps) => {
               />
 
               <XAxis
-                dataKey="week"
+                dataKey="weekLabel"
                 tickLine={false}
                 axisLine={false}
                 tick={{
@@ -342,7 +342,7 @@ const ChurchGraph = (props: ChurchGraphProps) => {
                   fontWeight: 500,
                 }}
                 interval={0}
-                tickFormatter={(week) => (week ? `W${week}` : '—')}
+                tickFormatter={(label) => label || '—'}
               />
               <YAxis
                 hide

--- a/web-react-ts/src/components/ChurchGraph/ChurchGraph.tsx
+++ b/web-react-ts/src/components/ChurchGraph/ChurchGraph.tsx
@@ -151,6 +151,8 @@ type TooltipEntry = {
   name?: string
   color?: string
   payload?: {
+    week?: number
+    year?: number
     numberOfServices?: number
     numberOfUrvans?: number
     numberOfSprinters?: number
@@ -167,11 +169,17 @@ type ChartTooltipProps = {
 const ChartTooltip = ({ active, payload, label }: ChartTooltipProps) => {
   if (!active || !payload?.length) return null
   const meta = payload[0]?.payload ?? {}
+  const headerLabel =
+    meta.week && meta.year
+      ? `Week ${meta.week}, ${meta.year}`
+      : meta.week
+      ? `Week ${meta.week}`
+      : label || ''
 
   return (
     <div className="min-w-44 rounded-xl border border-border bg-card px-3 py-2 shadow-lg">
       <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-        {label || ''}
+        {headerLabel}
       </p>
       <div className="mt-2 space-y-1.5">
         {payload.map((entry) => (

--- a/web-react-ts/src/pages/services/graphs/BacentaGraphs.tsx
+++ b/web-react-ts/src/pages/services/graphs/BacentaGraphs.tsx
@@ -124,12 +124,28 @@ export const BacentaGraphs = () => {
     setWindowEnd(null)
   }
 
-  const validWeeks = windowedData
-    .map((d: { week?: number | string }) => Number(d.week ?? 0))
-    .filter((n: number) => Number.isFinite(n) && n > 0)
-  const weekRangeLabel = validWeeks.length
-    ? `Weeks ${Math.min(...validWeeks)} – ${Math.max(...validWeeks)}`
-    : 'No service data'
+  const weekRangeLabel = useMemo(() => {
+    const validEntries = windowedData
+      .map((d: { week?: number | string; year?: number | string }) => ({
+        week: Number(d.week ?? 0),
+        year: Number(d.year ?? 0),
+      }))
+      .filter((e) => Number.isFinite(e.week) && e.week > 0)
+    if (!validEntries.length) return 'No service data'
+
+    const sorted = [...validEntries].sort(
+      (a, b) => a.year * 100 + a.week - (b.year * 100 + b.week)
+    )
+    const first = sorted[0]
+    const last = sorted[sorted.length - 1]
+    const formatWeekYear = (w: number, y: number) =>
+      y ? `W${w}'${String(y).slice(-2)}` : `W${w}`
+
+    if (first.year === last.year) {
+      return `Weeks ${first.week} – ${last.week} (${first.year})`
+    }
+    return `${formatWeekYear(first.week, first.year)} – ${formatWeekYear(last.week, last.year)}`
+  }, [windowedData])
 
   const showIncomeBar =
     graphs !== 'bussing' && !!getMonthlyStatAverage(weekdayData, 'income')

--- a/web-react-ts/src/pages/services/graphs/CampusGraphs.tsx
+++ b/web-react-ts/src/pages/services/graphs/CampusGraphs.tsx
@@ -147,12 +147,28 @@ const CampusGraphs = () => {
     setWindowEnd(null)
   }
 
-  const validWeeks = windowedData
-    .map((d: { week?: number | string }) => Number(d.week ?? 0))
-    .filter((n: number) => Number.isFinite(n) && n > 0)
-  const weekRangeLabel = validWeeks.length
-    ? `Weeks ${Math.min(...validWeeks)} – ${Math.max(...validWeeks)}`
-    : 'No service data'
+  const weekRangeLabel = useMemo(() => {
+    const validEntries = windowedData
+      .map((d: { week?: number | string; year?: number | string }) => ({
+        week: Number(d.week ?? 0),
+        year: Number(d.year ?? 0),
+      }))
+      .filter((e) => Number.isFinite(e.week) && e.week > 0)
+    if (!validEntries.length) return 'No service data'
+
+    const sorted = [...validEntries].sort(
+      (a, b) => a.year * 100 + a.week - (b.year * 100 + b.week)
+    )
+    const first = sorted[0]
+    const last = sorted[sorted.length - 1]
+    const formatWeekYear = (w: number, y: number) =>
+      y ? `W${w}'${String(y).slice(-2)}` : `W${w}`
+
+    if (first.year === last.year) {
+      return `Weeks ${first.week} – ${last.week} (${first.year})`
+    }
+    return `${formatWeekYear(first.week, first.year)} – ${formatWeekYear(last.week, last.year)}`
+  }, [windowedData])
 
   // Suppress income bar on USD tab — the chart title already signals the currency,
   // and the tooltip would format dollar values with GHS locale.

--- a/web-react-ts/src/pages/services/graphs/CouncilGraphs.tsx
+++ b/web-react-ts/src/pages/services/graphs/CouncilGraphs.tsx
@@ -134,12 +134,28 @@ const CouncilGraphs = () => {
     setWindowEnd(null)
   }
 
-  const validWeeks = windowedData
-    .map((d: { week?: number | string }) => Number(d.week ?? 0))
-    .filter((n: number) => Number.isFinite(n) && n > 0)
-  const weekRangeLabel = validWeeks.length
-    ? `Weeks ${Math.min(...validWeeks)} – ${Math.max(...validWeeks)}`
-    : 'No service data'
+  const weekRangeLabel = useMemo(() => {
+    const validEntries = windowedData
+      .map((d: { week?: number | string; year?: number | string }) => ({
+        week: Number(d.week ?? 0),
+        year: Number(d.year ?? 0),
+      }))
+      .filter((e) => Number.isFinite(e.week) && e.week > 0)
+    if (!validEntries.length) return 'No service data'
+
+    const sorted = [...validEntries].sort(
+      (a, b) => a.year * 100 + a.week - (b.year * 100 + b.week)
+    )
+    const first = sorted[0]
+    const last = sorted[sorted.length - 1]
+    const formatWeekYear = (w: number, y: number) =>
+      y ? `W${w}'${String(y).slice(-2)}` : `W${w}`
+
+    if (first.year === last.year) {
+      return `Weeks ${first.week} – ${last.week} (${first.year})`
+    }
+    return `${formatWeekYear(first.week, first.year)} – ${formatWeekYear(last.week, last.year)}`
+  }, [windowedData])
 
   const showIncomeBar =
     !isBussingTab && !!getMonthlyStatAverage(windowedData, 'income')

--- a/web-react-ts/src/pages/services/graphs/DenominationGraphs.tsx
+++ b/web-react-ts/src/pages/services/graphs/DenominationGraphs.tsx
@@ -145,12 +145,28 @@ const DenominationGraphs = () => {
     setWindowEnd(null)
   }
 
-  const validWeeks = windowedData
-    .map((d: { week?: number | string }) => Number(d.week ?? 0))
-    .filter((n: number) => Number.isFinite(n) && n > 0)
-  const weekRangeLabel = validWeeks.length
-    ? `Weeks ${Math.min(...validWeeks)} – ${Math.max(...validWeeks)}`
-    : 'No service data'
+  const weekRangeLabel = useMemo(() => {
+    const validEntries = windowedData
+      .map((d: { week?: number | string; year?: number | string }) => ({
+        week: Number(d.week ?? 0),
+        year: Number(d.year ?? 0),
+      }))
+      .filter((e) => Number.isFinite(e.week) && e.week > 0)
+    if (!validEntries.length) return 'No service data'
+
+    const sorted = [...validEntries].sort(
+      (a, b) => a.year * 100 + a.week - (b.year * 100 + b.week)
+    )
+    const first = sorted[0]
+    const last = sorted[sorted.length - 1]
+    const formatWeekYear = (w: number, y: number) =>
+      y ? `W${w}'${String(y).slice(-2)}` : `W${w}`
+
+    if (first.year === last.year) {
+      return `Weeks ${first.week} – ${last.week} (${first.year})`
+    }
+    return `${formatWeekYear(first.week, first.year)} – ${formatWeekYear(last.week, last.year)}`
+  }, [windowedData])
 
   const showIncomeBar =
     !isBussingTab &&

--- a/web-react-ts/src/pages/services/graphs/GovernorshipGraphs.tsx
+++ b/web-react-ts/src/pages/services/graphs/GovernorshipGraphs.tsx
@@ -144,12 +144,28 @@ export const GovernorshipGraphs = () => {
     setWindowEnd(null)
   }
 
-  const validWeeks = windowedData
-    .map((d: { week?: number | string }) => Number(d.week ?? 0))
-    .filter((n: number) => Number.isFinite(n) && n > 0)
-  const weekRangeLabel = validWeeks.length
-    ? `Weeks ${Math.min(...validWeeks)} – ${Math.max(...validWeeks)}`
-    : 'No service data'
+  const weekRangeLabel = useMemo(() => {
+    const validEntries = windowedData
+      .map((d: { week?: number | string; year?: number | string }) => ({
+        week: Number(d.week ?? 0),
+        year: Number(d.year ?? 0),
+      }))
+      .filter((e) => Number.isFinite(e.week) && e.week > 0)
+    if (!validEntries.length) return 'No service data'
+
+    const sorted = [...validEntries].sort(
+      (a, b) => a.year * 100 + a.week - (b.year * 100 + b.week)
+    )
+    const first = sorted[0]
+    const last = sorted[sorted.length - 1]
+    const formatWeekYear = (w: number, y: number) =>
+      y ? `W${w}'${String(y).slice(-2)}` : `W${w}`
+
+    if (first.year === last.year) {
+      return `Weeks ${first.week} – ${last.week} (${first.year})`
+    }
+    return `${formatWeekYear(first.week, first.year)} – ${formatWeekYear(last.week, last.year)}`
+  }, [windowedData])
 
   const showIncomeBar =
     !isBussingTab && !!getMonthlyStatAverage(windowedData, 'income')

--- a/web-react-ts/src/pages/services/graphs/OversightGraphs.tsx
+++ b/web-react-ts/src/pages/services/graphs/OversightGraphs.tsx
@@ -146,12 +146,28 @@ const OversightGraphs = () => {
     setWindowEnd(null)
   }
 
-  const validWeeks = windowedData
-    .map((d: { week?: number | string }) => Number(d.week ?? 0))
-    .filter((n: number) => Number.isFinite(n) && n > 0)
-  const weekRangeLabel = validWeeks.length
-    ? `Weeks ${Math.min(...validWeeks)} – ${Math.max(...validWeeks)}`
-    : 'No service data'
+  const weekRangeLabel = useMemo(() => {
+    const validEntries = windowedData
+      .map((d: { week?: number | string; year?: number | string }) => ({
+        week: Number(d.week ?? 0),
+        year: Number(d.year ?? 0),
+      }))
+      .filter((e) => Number.isFinite(e.week) && e.week > 0)
+    if (!validEntries.length) return 'No service data'
+
+    const sorted = [...validEntries].sort(
+      (a, b) => a.year * 100 + a.week - (b.year * 100 + b.week)
+    )
+    const first = sorted[0]
+    const last = sorted[sorted.length - 1]
+    const formatWeekYear = (w: number, y: number) =>
+      y ? `W${w}'${String(y).slice(-2)}` : `W${w}`
+
+    if (first.year === last.year) {
+      return `Weeks ${first.week} – ${last.week} (${first.year})`
+    }
+    return `${formatWeekYear(first.week, first.year)} – ${formatWeekYear(last.week, last.year)}`
+  }, [windowedData])
 
   const showIncomeBar =
     !isBussingTab &&

--- a/web-react-ts/src/pages/services/graphs/StreamGraphs.tsx
+++ b/web-react-ts/src/pages/services/graphs/StreamGraphs.tsx
@@ -134,12 +134,28 @@ const StreamGraphs = () => {
     setWindowEnd(null)
   }
 
-  const validWeeks = windowedData
-    .map((d: { week?: number | string }) => Number(d.week ?? 0))
-    .filter((n: number) => Number.isFinite(n) && n > 0)
-  const weekRangeLabel = validWeeks.length
-    ? `Weeks ${Math.min(...validWeeks)} – ${Math.max(...validWeeks)}`
-    : 'No service data'
+  const weekRangeLabel = useMemo(() => {
+    const validEntries = windowedData
+      .map((d: { week?: number | string; year?: number | string }) => ({
+        week: Number(d.week ?? 0),
+        year: Number(d.year ?? 0),
+      }))
+      .filter((e) => Number.isFinite(e.week) && e.week > 0)
+    if (!validEntries.length) return 'No service data'
+
+    const sorted = [...validEntries].sort(
+      (a, b) => a.year * 100 + a.week - (b.year * 100 + b.week)
+    )
+    const first = sorted[0]
+    const last = sorted[sorted.length - 1]
+    const formatWeekYear = (w: number, y: number) =>
+      y ? `W${w}'${String(y).slice(-2)}` : `W${w}`
+
+    if (first.year === last.year) {
+      return `Weeks ${first.week} – ${last.week} (${first.year})`
+    }
+    return `${formatWeekYear(first.week, first.year)} – ${formatWeekYear(last.week, last.year)}`
+  }, [windowedData])
 
   const showIncomeBar =
     !isBussingTab && !!getMonthlyStatAverage(windowedData, 'income')

--- a/web-react-ts/src/pages/services/graphs/graphs-utils.ts
+++ b/web-react-ts/src/pages/services/graphs/graphs-utils.ts
@@ -160,18 +160,27 @@ export const getServiceGraphData = (
   }
   let data: any[] = []
 
+  const currentYear = new Date().getFullYear()
+
   const pushIntoData = (array: any[]) => {
     if (!array || array?.length === 0) {
       return
     }
 
     array.forEach((record) => {
+      const week = record.week
+      const year = record.year
+      const yearSuffix =
+        typeof year === 'number' && year !== currentYear
+          ? `'${String(year).slice(-2)}`
+          : ''
       data.push({
         id: record?.id,
         category,
         date: record?.serviceDate?.date || record.date,
-        week: record.week,
-        year: record.year,
+        week,
+        year,
+        weekLabel: week ? `W${week}${yearSuffix}` : null,
         attendance: record.attendance,
         income: record.income?.toFixed(2),
         numberOfServices: record?.numberOfServices,


### PR DESCRIPTION
This pull request improves how week and year information is handled and displayed across service graph components. The changes enhance the clarity of week ranges and tooltips by including year data where relevant, and refactor the logic to be more robust and maintainable.

**Improvements to week/year display and labeling:**

- Updated the logic for calculating and displaying week range labels in all service graph components (such as `BacentaGraphs`, `CampusGraphs`, `CouncilGraphs`, `DenominationGraphs`, `GovernorshipGraphs`, `OversightGraphs`, `StreamGraphs`). The new logic includes the year in the label and formats ranges spanning multiple years more clearly. [[1]](diffhunk://#diff-fa61175020913e05394a27d7c56df3d15ebb288c45b40bb5d1f841b4d60213d8L127-R148) [[2]](diffhunk://#diff-5287f11a60bfcf6d5258fc57a3dc8269d83b570e7254ff06e3e91a2d1aaa00afL150-R171) [[3]](diffhunk://#diff-c281f6f2cf7c34c1349e80073a57ea8fd5e58b25a6f37e587fe3b96a3cbee8fdL137-R158) [[4]](diffhunk://#diff-c5050a6dabb4a1ba3e56a61bccb99db50722fa958159a248f90533ec412beba5L148-R169) [[5]](diffhunk://#diff-cc6dade65d8d0c8c3a3805864ec7038d6f5f0d92a5e03bec4ec7a838adb36612L147-R168) [[6]](diffhunk://#diff-c88f409bdcfba80bf16379cba14a4e2e0800c21ad68cc7995ed39757b14078feL149-R170) [[7]](diffhunk://#diff-a348989e773dc8790d32e13831605a76bdb485dad33f3305d9cd14a566c455a5L137-R158)

- Modified the graph data utility (`getServiceGraphData` in `graphs-utils.ts`) to generate a `weekLabel` that includes the year suffix for weeks not in the current year, improving clarity in axis labeling and tooltips.

**Enhancements to tooltips and axis labeling in `ChurchGraph`:**

- Extended the `TooltipEntry` type and tooltip rendering logic to include both week and year, so tooltips now show "Week N, YYYY" when both are available. [[1]](diffhunk://#diff-e8a5d26a2222bbfcae194ab484f60799f73e170fc0f094d5b77546f4e8d04c03R154-R155) [[2]](diffhunk://#diff-e8a5d26a2222bbfcae194ab484f60799f73e170fc0f094d5b77546f4e8d04c03R172-R182)

- Updated the X-axis in `ChurchGraph` to use the new `weekLabel` field and simplified the tick formatter, ensuring consistent and informative labeling. [[1]](diffhunk://#diff-e8a5d26a2222bbfcae194ab484f60799f73e170fc0f094d5b77546f4e8d04c03L336-R344) [[2]](diffhunk://#diff-e8a5d26a2222bbfcae194ab484f60799f73e170fc0f094d5b77546f4e8d04c03L345-R353)