### PR TITLE
Fix church closure validations and add banking check for bacenta

### DIFF
--- a/api/src/resolvers/cypher/close-church-cypher.ts
+++ b/api/src/resolvers/cypher/close-church-cypher.ts
@@ -38,8 +38,8 @@ RETURN campus.name AS name, COUNT(member) AS memberCount, COUNT(streams) AS stre
 `
 export const checkOversightHasNoMembers = `//cypher
 MATCH (oversight:Oversight {id:$oversightId})
-MATCH (oversight)-[:HAS]->(campuses:Campus)<-[:LEADS]-(member:Active:Member)
-RETURN oversight.name AS name, COUNT(member) AS memberCount, COUNT(campuses) AS campusCount
+OPTIONAL MATCH (oversight)-[:HAS]->(campuses:Campus)
+RETURN oversight.name AS name, COUNT(campuses) AS campusCount
 `
 
 export const closeDownBacenta = `//cypher
@@ -180,7 +180,7 @@ RETURN oversight {
 `
 
 export const closeDownOversight = `//cypher
-MATCH (oversight:OverSight {id:$oversightId})<-[:HAS]-(denomination:Denomination)
+MATCH (oversight:Oversight {id:$oversightId})<-[:HAS]-(denomination:Denomination)
 WITH oversight, denomination
 
 CREATE (log:HistoryLog {id:apoc.create.uuid()})

--- a/api/src/resolvers/cypher/close-church-cypher.ts
+++ b/api/src/resolvers/cypher/close-church-cypher.ts
@@ -21,20 +21,23 @@ RETURN governorship.name AS name,  COUNT(bacentas) AS bacentaCount
 `
 export const checkCouncilHasNoMembers = `//cypher
 MATCH (council:Council {id:$councilId})
-OPTIONAL MATCH (council)-[:HAS]->(governorships:Governorship)<-[:LEADS]-(member:Active:Member)
-RETURN council.name AS name, COUNT(member) AS memberCount, COUNT(governorships) AS governorshipCount
+OPTIONAL MATCH (council)-[:HAS]->(governorships:Governorship)
+RETURN council.name AS name, COUNT(governorships) AS governorshipCount
 `
 
 export const checkStreamHasNoMembers = `//cypher
 MATCH (stream:Stream {id:$streamId})
-OPTIONAL MATCH (stream)-[:HAS]->(councils:Council)<-[:LEADS]-(member:Active:Member)
-OPTIONAL MATCH (stream)-[:HAS_MINISTRY]->(ministries:Ministry)<-[:LEADS]-(leader:Active:Member)
-RETURN stream.name AS name, COUNT(member) AS memberCount, COUNT(councils) AS councilCount, COUNT(leader) AS ministryLeaderCount, COUNT(ministries) as ministryCount
+OPTIONAL MATCH (stream)-[:HAS]->(councils:Council)
+// Councils drop their :Council label on close-down, so (councils:Council) already
+// excludes closed ones. Ministries keep :Ministry and gain :ClosedMinistry, so they
+// need the explicit filter below.
+OPTIONAL MATCH (stream)-[:HAS_MINISTRY]->(ministries:Ministry) WHERE NOT ministries:ClosedMinistry
+RETURN stream.name AS name, COUNT(DISTINCT councils) AS councilCount, COUNT(DISTINCT ministries) AS ministryCount
 `
 export const checkCampusHasNoMembers = `//cypher
 MATCH (campus:Campus {id:$campusId})
-OPTIONAL MATCH (campus)-[:HAS]->(streams:Stream)<-[:LEADS]-(member:Active:Member)
-RETURN campus.name AS name, COUNT(member) AS memberCount, COUNT(streams) AS streamCount
+OPTIONAL MATCH (campus)-[:HAS]->(streams:Stream)
+RETURN campus.name AS name, COUNT(streams) AS streamCount
 `
 export const checkOversightHasNoMembers = `//cypher
 MATCH (oversight:Oversight {id:$oversightId})

--- a/api/src/resolvers/directory/directory-resolvers.ts
+++ b/api/src/resolvers/directory/directory-resolvers.ts
@@ -449,13 +449,13 @@ const directoryMutation = {
       const streamCheck = rearrangeCypherObject(res[0])
       const lastServiceRecord = rearrangeCypherObject(res[1])
 
-      if (streamCheck.memberCount > 0) {
+      if (streamCheck.councilCount.toNumber()) {
         throw new Error(
           `${streamCheck?.name} Stream has ${streamCheck?.councilCount} active councils. Please close down all councils and try again.`
         )
       }
 
-      if (streamCheck.ministryLeaderCount > 0) {
+      if (streamCheck.ministryCount.toNumber()) {
         throw new Error(
           `${streamCheck?.name} Stream has ${streamCheck?.ministryCount} active ministries. Please close down all ministries and try again.`
         )
@@ -539,7 +539,7 @@ const directoryMutation = {
       const campusCheck = rearrangeCypherObject(res[0])
       const lastServiceRecord = rearrangeCypherObject(res[1])
 
-      if (campusCheck.memberCount > 0) {
+      if (campusCheck.streamCount.toNumber()) {
         throw new Error(
           `${campusCheck?.name} Campus has ${campusCheck?.streamCount} active streams. Please close down all streams and try again.`
         )

--- a/api/src/resolvers/directory/directory-resolvers.ts
+++ b/api/src/resolvers/directory/directory-resolvers.ts
@@ -190,16 +190,44 @@ const directoryMutation = {
     isAuth(permitAdminArrivals('Governorship'), context.jwt?.roles)
 
     const session = context.executionContext.session()
+    const sessionTwo = context.executionContext.session()
 
     try {
-      const bacentaCheckResponse = await session.executeRead((tx) =>
-        tx.run(closeChurchCypher.checkBacentaHasNoMembers, args)
-      )
-      const bacentaCheck = rearrangeCypherObject(bacentaCheckResponse)
+      const res: any = await Promise.all([
+        session.executeRead((tx) =>
+          tx.run(closeChurchCypher.checkBacentaHasNoMembers, args)
+        ),
+        sessionTwo.executeRead((tx) =>
+          tx.run(closeChurchCypher.getLastServiceRecord, {
+            churchId: args.bacentaId,
+          })
+        ),
+      ])
+
+      const bacentaCheck = rearrangeCypherObject(res[0])
+      const lastServiceRecord = rearrangeCypherObject(res[1])
 
       if (bacentaCheck.memberCount > 0) {
         throw new Error(
           `${bacentaCheck?.name} Bacenta has ${bacentaCheck?.memberCount} members. Please transfer all members and try again.`
+        )
+      }
+
+      const record = lastServiceRecord.lastService?.properties ?? {
+        bankingSlip: null,
+      }
+
+      if (
+        !(
+          'bankingSlip' in record ||
+          record.transactionStatus === 'success' ||
+          'tellerConfirmationTime' in record
+        )
+      ) {
+        throw new Error(
+          `Please bank outstanding offering for your service filled on ${getHumanReadableDate(
+            record.createdAt
+          )} before attempting to close down this bacenta`
         )
       }
 
@@ -227,6 +255,7 @@ const directoryMutation = {
       throw error
     } finally {
       await session.close()
+      await sessionTwo.close()
     }
   },
   CloseDownGovernorship: async (object: any, args: any, context: Context) => {
@@ -594,7 +623,7 @@ const directoryMutation = {
       const oversightCheck = rearrangeCypherObject(res[0])
       const lastServiceRecord = rearrangeCypherObject(res[1])
 
-      if (oversightCheck.memberCount) {
+      if (oversightCheck.campusCount.toNumber()) {
         throw new Error(
           `${oversightCheck?.name} Oversight has ${oversightCheck?.campusCount} active campuses. Please close down all campuses and try again.`
         )


### PR DESCRIPTION
## Description

This PR fixes several issues in the church closure validation logic across multiple organizational levels (Bacenta, Council, Stream, Campus, Oversight):

### Key Changes

1. **Bacenta closure** — Added validation to ensure outstanding offerings are banked before closure. Now fetches the last service record in parallel and checks that banking has been completed (via `bankingSlip`, `transactionStatus === 'success'`, or `tellerConfirmationTime`).

2. **Fixed validation logic** — Corrected incorrect field references in closure checks:
   - `CloseDownStream`: Changed `streamCheck.memberCount` → `streamCheck.councilCount.toNumber()` and `streamCheck.ministryLeaderCount` → `streamCheck.ministryCount.toNumber()`
   - `CloseDownCampus`: Changed `campusCheck.memberCount` → `campusCheck.streamCount.toNumber()`
   - `CloseDownOversight`: Changed `oversightCheck.memberCount` → `oversightCheck.campusCount.toNumber()`

3. **Improved Cypher queries** — Refactored closure check queries to:
   - Count organizational units (councils, ministries, streams, campuses) directly instead of counting members
   - Remove unnecessary member-counting logic that was causing incorrect validation results
   - Added explicit filter for closed ministries in stream check (`WHERE NOT ministries:ClosedMinistry`)
   - Fixed typo: `OverSight` → `Oversight` in closeDownOversight query

4. **Session management** — Added proper cleanup of a second database session used for fetching the last service record in bacenta closure.

### Why These Changes

The original validation logic was checking member counts instead of child organizational unit counts, which meant closures could be blocked incorrectly or allowed when they shouldn't be. The bacenta closure now also prevents data integrity issues by ensuring all financial records are settled before closure.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The changes align with existing resolver patterns and Neo4j query structure. Validation logic now correctly counts organizational units rather than members, which matches the intent of the closure checks. The parallel session fetch for banking validation follows the same pattern used elsewhere in the codebase.

https://claude.ai/code/session_01NC3KU7vwkjMwhHpjp5mGsi