### PR TITLE
Add daily stewardship verses to banking reminders

### DIFF
--- a/api/src/functions/background/push-reminders/banking-message.js
+++ b/api/src/functions/background/push-reminders/banking-message.js
@@ -21,17 +21,28 @@ const formatMoney = (amount, currency) => {
   return `${currency || 'GHS'} ${value.toLocaleString('en-GH')}`
 }
 
-// Stewardship scriptures that open the banking reminder. These frame the
-// unbanked offering as funds held in trust (not the leader's own money), so the
-// set is drawn from verses about faithfulness with what is entrusted and
-// honesty in handling money — not personal-giving / tithing verses. Verse text
-// only: the reminder body still carries the "Please bank it today." call to
-// action, so the scripture supplies the "why", not a second instruction.
+// Stewardship scriptures that open the banking reminder. They frame the
+// unbanked offering as funds held in trust (not the leader's own money): the
+// set leans on faithfulness with what is entrusted and honesty in handling
+// money. Malachi's "rob God" is included as a warning reframed for this
+// context — the leader is holding the congregation's offering *to* God, not
+// their own giving. Verse text only: the reminder body still carries the
+// "Please bank it today." call to action, so the scripture supplies the "why",
+// not a second instruction.
 const BANKING_VERSES = [
+  // Faithfulness with what is entrusted to you
   '1 Cor 4:2 — It is required of stewards that they be found faithful.',
   'Luke 16:10 — Whoever is faithful in a very little is faithful also in much.',
-  'Lev 19:11 — You shall not steal, nor deal falsely with one another.',
+  "Luke 16:12 — If you have not been faithful in that which is another's, who will give you that which is your own?",
+  'Luke 12:42 — Who then is the faithful and wise steward, whom his master will set over his household?',
+  // Theft / withholding / honest measure
+  'Lev 19:11 — You shall not steal, nor deal falsely, nor lie to one another.',
+  'Lev 19:13 — You shall not oppress your neighbour or rob him.',
   'Prov 11:1 — A false balance is an abomination to the Lord, but a just weight is his delight.',
+  'Mal 3:8 — Will a man rob God? Yet you are robbing me.',
+  // Honesty and accountability before God
+  '2 Kings 12:15 — They required no accounting, for they dealt honestly.',
+  'Acts 5:4 — You have not lied to men but to God.',
 ]
 
 /**

--- a/api/src/functions/background/push-reminders/banking-message.js
+++ b/api/src/functions/background/push-reminders/banking-message.js
@@ -21,11 +21,11 @@ const formatMoney = (amount, currency) => {
   return `${currency || 'GHS'} ${value.toLocaleString('en-GH')}`
 }
 
-// Stewardship scriptures appended to the banking reminder. These frame the
+// Stewardship scriptures that open the banking reminder. These frame the
 // unbanked offering as funds held in trust (not the leader's own money), so the
 // set is drawn from verses about faithfulness with what is entrusted and
 // honesty in handling money — not personal-giving / tithing verses. Verse text
-// only: the reminder body already carries the "Please bank it today." call to
+// only: the reminder body still carries the "Please bank it today." call to
 // action, so the scripture supplies the "why", not a second instruction.
 const BANKING_VERSES = [
   '1 Cor 4:2 — It is required of stewards that they be found faithful.',
@@ -70,13 +70,13 @@ const buildBankingBody = (row, now = new Date()) => {
           row.unbanked.length > 2 ? 's' : ''
         })`
       : ''
-  return `${row.churchName}: ${formatMoney(
+  return `${pickVerse(now)}\n\n${row.churchName}: ${formatMoney(
     latest.income,
     latest.foreignCurrency
   )} from your service ${describeServiceDate(
     latest.date,
     now
-  )} hasn't been banked yet${more}. Please bank it today.\n\n${pickVerse(now)}`
+  )} hasn't been banked yet${more}. Please bank it today.`
 }
 
 module.exports = {

--- a/api/src/functions/background/push-reminders/banking-message.js
+++ b/api/src/functions/background/push-reminders/banking-message.js
@@ -21,6 +21,36 @@ const formatMoney = (amount, currency) => {
   return `${currency || 'GHS'} ${value.toLocaleString('en-GH')}`
 }
 
+// Stewardship scriptures appended to the banking reminder. These frame the
+// unbanked offering as funds held in trust (not the leader's own money), so the
+// set is drawn from verses about faithfulness with what is entrusted and
+// honesty in handling money — not personal-giving / tithing verses. Verse text
+// only: the reminder body already carries the "Please bank it today." call to
+// action, so the scripture supplies the "why", not a second instruction.
+const BANKING_VERSES = [
+  '1 Cor 4:2 — It is required of stewards that they be found faithful.',
+  'Luke 16:10 — Whoever is faithful in a very little is faithful also in much.',
+  'Lev 19:11 — You shall not steal, nor deal falsely with one another.',
+  'Prov 11:1 — A false balance is an abomination to the Lord, but a just weight is his delight.',
+]
+
+/**
+ * Pick the day's verse. Rotation is keyed on the UTC calendar day so it is
+ * deterministic (every recipient on a given day sees the same verse, and the
+ * choice is unit-testable from `now` alone) and advances one verse per day.
+ * Ghana is UTC+0 year-round, so the UTC day IS the Accra day.
+ *
+ * @param {Date} now  reference "today"
+ * @returns {string} one of BANKING_VERSES
+ */
+const pickVerse = (now = new Date()) => {
+  const dayNumber = Math.floor(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()) /
+      (24 * 60 * 60 * 1000)
+  )
+  return BANKING_VERSES[dayNumber % BANKING_VERSES.length]
+}
+
 /**
  * Build the banking-reminder notification body for one recipient row.
  *
@@ -46,7 +76,13 @@ const buildBankingBody = (row, now = new Date()) => {
   )} from your service ${describeServiceDate(
     latest.date,
     now
-  )} hasn't been banked yet${more}. Please bank it today.`
+  )} hasn't been banked yet${more}. Please bank it today.\n\n${pickVerse(now)}`
 }
 
-module.exports = { toNumber, formatMoney, buildBankingBody }
+module.exports = {
+  toNumber,
+  formatMoney,
+  buildBankingBody,
+  pickVerse,
+  BANKING_VERSES,
+}

--- a/api/src/functions/background/push-reminders/banking-message.test.js
+++ b/api/src/functions/background/push-reminders/banking-message.test.js
@@ -18,7 +18,8 @@ const {
 const NOW = new Date('2026-07-09T15:00:00.000Z')
 
 // Rotation is keyed on the UTC calendar day, so NOW deterministically resolves
-// to a single verse. 2026-07-09 is day 20643 since epoch; 20643 % 4 === 3.
+// to a single verse. 2026-07-09 is day 20643 since epoch; with a 10-verse pool
+// 20643 % 10 === 3.
 const VERSE_ON_NOW = BANKING_VERSES[3]
 
 const row = (overrides = {}) => ({
@@ -144,12 +145,20 @@ describe('pickVerse', () => {
   })
 
   it('advances one verse per day and wraps around the set', () => {
-    // 2026-07-09 → index 3 (last); the next day wraps back to index 0.
+    // Consecutive days step to consecutive indices (07-09 → 3, so 07-10 → 4,
+    // 07-11 → 5).
     expect(pickVerse(new Date('2026-07-10T15:00:00.000Z'))).toBe(
-      BANKING_VERSES[0]
+      BANKING_VERSES[4]
     )
     expect(pickVerse(new Date('2026-07-11T15:00:00.000Z'))).toBe(
-      BANKING_VERSES[1]
+      BANKING_VERSES[5]
+    )
+    // 2026-07-15 lands on the final index; the next day wraps back to 0.
+    expect(pickVerse(new Date('2026-07-15T15:00:00.000Z'))).toBe(
+      BANKING_VERSES[BANKING_VERSES.length - 1]
+    )
+    expect(pickVerse(new Date('2026-07-16T15:00:00.000Z'))).toBe(
+      BANKING_VERSES[0]
     )
   })
 })

--- a/api/src/functions/background/push-reminders/banking-message.test.js
+++ b/api/src/functions/background/push-reminders/banking-message.test.js
@@ -57,15 +57,15 @@ describe('formatMoney', () => {
 describe('buildBankingBody', () => {
   it('names the church, the money, and the relative service date', () => {
     expect(buildBankingBody(row(), NOW)).toBe(
-      "Accra Central: GHS 500 from your service yesterday hasn't been banked yet. Please bank it today." +
-        `\n\n${VERSE_ON_NOW}`
+      `${VERSE_ON_NOW}\n\n` +
+        "Accra Central: GHS 500 from your service yesterday hasn't been banked yet. Please bank it today."
     )
   })
 
-  it("appends the day's stewardship verse after the call to action", () => {
+  it("opens with the day's stewardship verse, then the call to action", () => {
     const body = buildBankingBody(row(), NOW)
+    expect(body.startsWith(`${VERSE_ON_NOW}\n\n`)).toBe(true)
     expect(body).toContain('Please bank it today.')
-    expect(body.endsWith(`\n\n${VERSE_ON_NOW}`)).toBe(true)
     expect(BANKING_VERSES).toContain(VERSE_ON_NOW)
   })
 

--- a/api/src/functions/background/push-reminders/banking-message.test.js
+++ b/api/src/functions/background/push-reminders/banking-message.test.js
@@ -7,9 +7,19 @@
  * `toString(serviceDate.date)` shape produced by BANKING_REMINDER_RECIPIENTS.
  */
 
-const { toNumber, formatMoney, buildBankingBody } = require('./banking-message')
+const {
+  toNumber,
+  formatMoney,
+  buildBankingBody,
+  pickVerse,
+  BANKING_VERSES,
+} = require('./banking-message')
 
 const NOW = new Date('2026-07-09T15:00:00.000Z')
+
+// Rotation is keyed on the UTC calendar day, so NOW deterministically resolves
+// to a single verse. 2026-07-09 is day 20643 since epoch; 20643 % 4 === 3.
+const VERSE_ON_NOW = BANKING_VERSES[3]
 
 const row = (overrides = {}) => ({
   churchId: 'bacenta-1',
@@ -47,8 +57,16 @@ describe('formatMoney', () => {
 describe('buildBankingBody', () => {
   it('names the church, the money, and the relative service date', () => {
     expect(buildBankingBody(row(), NOW)).toBe(
-      "Accra Central: GHS 500 from your service yesterday hasn't been banked yet. Please bank it today."
+      "Accra Central: GHS 500 from your service yesterday hasn't been banked yet. Please bank it today." +
+        `\n\n${VERSE_ON_NOW}`
     )
+  })
+
+  it("appends the day's stewardship verse after the call to action", () => {
+    const body = buildBankingBody(row(), NOW)
+    expect(body).toContain('Please bank it today.')
+    expect(body.endsWith(`\n\n${VERSE_ON_NOW}`)).toBe(true)
+    expect(BANKING_VERSES).toContain(VERSE_ON_NOW)
   })
 
   it('uses the weekday name for a 3–6 day old service', () => {
@@ -110,5 +128,28 @@ describe('buildBankingBody', () => {
       NOW
     )
     expect(body).toContain('GHS 999 from your service yesterday')
+  })
+})
+
+describe('pickVerse', () => {
+  it('returns a verse from the BANKING_VERSES set', () => {
+    expect(BANKING_VERSES).toContain(pickVerse(NOW))
+  })
+
+  it('is deterministic for a given UTC calendar day', () => {
+    const morning = new Date('2026-07-09T06:00:00.000Z')
+    const evening = new Date('2026-07-09T21:30:00.000Z')
+    expect(pickVerse(morning)).toBe(pickVerse(evening))
+    expect(pickVerse(NOW)).toBe(VERSE_ON_NOW)
+  })
+
+  it('advances one verse per day and wraps around the set', () => {
+    // 2026-07-09 → index 3 (last); the next day wraps back to index 0.
+    expect(pickVerse(new Date('2026-07-10T15:00:00.000Z'))).toBe(
+      BANKING_VERSES[0]
+    )
+    expect(pickVerse(new Date('2026-07-11T15:00:00.000Z'))).toBe(
+      BANKING_VERSES[1]
+    )
   })
 })


### PR DESCRIPTION
## Description

Adds a rotating daily stewardship verse to the opening of banking reminder notifications. The verse selection is deterministic based on UTC calendar day, ensuring all recipients see the same verse on a given day and the rotation advances one verse per day.

### Changes

- **New `BANKING_VERSES` constant**: A curated set of 10 scriptures focused on faithfulness with entrusted funds, honest dealing, and accountability. Verses frame unbanked offerings as funds held in trust (not the leader's own money).
- **New `pickVerse(now)` function**: Selects the day's verse deterministically by converting the UTC date to days since epoch, then indexing into `BANKING_VERSES` with modulo arithmetic. Ghana is UTC+0 year-round, so UTC day = Accra day.
- **Updated `buildBankingBody()`**: Now prepends the day's verse (via `pickVerse()`) to the reminder body, separated by two newlines.
- **Exports**: `pickVerse` and `BANKING_VERSES` are now exported for testing and reuse.

### Testing

Added comprehensive test coverage:
- `pickVerse()` returns a verse from the set
- `pickVerse()` is deterministic for a given UTC calendar day (same verse for morning and evening)
- `pickVerse()` advances one verse per day and wraps around the set
- `buildBankingBody()` now opens with the day's verse followed by the call to action

All new tests pass; existing `buildBankingBody()` test updated to expect the verse prefix.

https://claude.ai/code/session_01X6xEwwWj8h7jNAf1tcWfq7